### PR TITLE
Support building freeglut in Regal-mode

### DIFF
--- a/freeglut/include/GL/freeglut_std.h
+++ b/freeglut/include/GL/freeglut_std.h
@@ -132,7 +132,10 @@
 /* Note: FREEGLUT_GLES1 and FREEGLUT_GLES2 are only used to cleanly
    bootstrap headers inclusion here; use GLES constants directly
    (e.g. GL_ES_VERSION_2_0) for all other needs */
-#ifdef FREEGLUT_GLES2
+#ifdef FREEGLUT_REGAL
+#   include <GL/Regal.h>
+#   include <GL/RegalGLU.h>
+#elif FREEGLUT_GLES2
 #   include <EGL/egl.h>
 #   include <GLES2/gl2.h>
 #elif FREEGLUT_GLES1

--- a/freeglut/src/egl/fg_internal_egl.h
+++ b/freeglut/src/egl/fg_internal_egl.h
@@ -26,7 +26,11 @@
 #ifndef  FREEGLUT_INTERNAL_EGL_H
 #define  FREEGLUT_INTERNAL_EGL_H
 
+#ifdef FREEGLUT_REGAL
+#include <GL/Regal.h>
+#else
 #include <EGL/egl.h>
+#endif
 
 /* -- GLOBAL TYPE DEFINITIONS ---------------------------------------------- */
 /* The structure used by display initialization in freeglut_init.c */

--- a/freeglut/src/x11/fg_internal_x11.h
+++ b/freeglut/src/x11/fg_internal_x11.h
@@ -33,8 +33,10 @@
 #ifdef EGL_VERSION_1_0
 #include "egl/fg_internal_egl.h"
 #else
+#ifndef FREEGLUT_REGAL
 #include <GL/glx.h>
 #include "x11/fg_internal_x11_glx.h"
+#endif
 #endif
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>

--- a/freeglut/src/x11/fg_window_x11.c
+++ b/freeglut/src/x11/fg_window_x11.c
@@ -387,6 +387,10 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
     );
 #endif
 
+#ifdef FREEGLUT_REGAL
+    RegalMakeCurrent(window->Window.Context);
+#endif
+
     /* register extension events _before_ window is mapped */
     #ifdef HAVE_X11_EXTENSIONS_XINPUT2_H
        fgRegisterDevices( fgDisplay.pDisplay.Display, &(window->Window.Handle) );


### PR DESCRIPTION
Using <GL/Regal.h> rather than various GL/ES/GLX platform-specific headers
No side-effects unless FREEGLUT_REGAL is defined

Sourceforge bug 190
https://sourceforge.net/p/freeglut/bugs/190/
