### PR TITLE
Fix issues with context lost on Android

### DIFF
--- a/freeglut/freeglut/src/android/fg_window_android.c
+++ b/freeglut/freeglut/src/android/fg_window_android.c
@@ -83,6 +83,14 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
 
   fghPlatformOpenWindowEGL(window);
 
+  /* Bind context to the current thread if it's lost */
+  if (eglGetCurrentContext() == EGL_NO_CONTEXT &&
+      eglMakeCurrent(fgDisplay.pDisplay.egl.Display,
+             window->Window.pContext.egl.Surface,
+             window->Window.pContext.egl.Surface,
+             window->Window.Context) == EGL_FALSE)
+    fgError("eglMakeCurrent: err=%x\n", eglGetError());
+
   window->State.Visible = GL_TRUE;
 }
 


### PR DESCRIPTION
This issue could be reproduced on a test-shapes-gles1 simply by switching an app between foreground and background- when resumed libEGL complained about "call to OpenGL ES API with no current context".

Alternative solution would be to trick `fgPlatformSetWindow()` into doing it by setting `fgStructure.CurrentWindow` to null before calling `fghPlatformOpenWindowEGL()`, but I think being explicit is cleaner.
