### PR TITLE
Docs update related to BlackBerry 10

### DIFF
--- a/freeglut/web-src/docs/api.php
+++ b/freeglut/web-src/docs/api.php
@@ -231,7 +231,7 @@ will thus not work with the currently available 2.8.1 release.
 			<li>glutMultiPassiveFunc &larr; id, x, y</li>
 		</ol>
 	</li>
-	<li><a href="#Android">Android functions</a>
+	<li><a href="#Mobile">Mobile functions</a>
 		<ol>
 			<li>glutInitContextFunc &larr; void</li>
 			<li>glutAppStatusFunc &larr; event</li>
@@ -2528,11 +2528,11 @@ desirable to get the device id as well in the following situations:
 
 </ul>
 
-Since this extra support comes at the cost of extra complexity, we're
+<p>Since this extra support comes at the cost of extra complexity, we're
 <a href="http://sourceforge.net/mailarchive/forum.php?thread_name=20120518071314.GA28061%40perso.beuc.net&forum_name=freeglut-developer">considering</a>
-whether/how to implement it.
+whether/how to implement it.</p>
 
-<h1><a name="Android"></a>Android Functions</h1>
+<h1><a name="Mobile"></a>Mobile Functions</h1>
 
 <p>These new callbacks were added:</p>
 
@@ -2547,9 +2547,14 @@ Possible states:
 <li>application comes back from a pause &rarr; GLUT_APPSTATUS_RESUME. Is
 called after the <code>glutInitContextFunc</code> callback.</li>
 </ul>
+</ul>
 
-<p>Android support is further described at
-the <a href="android.php">Android page</a>.</p>
+<p>Supported mobile platforms</p>
+<ul>
+<li>Android support is further described at
+the <a href="android.php">Android page</a>.</li>
+<li>BlackBerry 10/BlackBerry PlayBook</li>
+</ul>
 
 <h1>19. <a name="Miscellaneous"></a>Miscellaneous Functions</h1>
 

--- a/freeglut/web-src/docs/gles.php
+++ b/freeglut/web-src/docs/gles.php
@@ -20,11 +20,15 @@ generateHeader($_SERVER['PHP_SELF']);
 <p>FreeGLUT can initialize an OpenGL ES (GLES) context.  It works under platforms that supports EGL:</p>
 <ul>
   <li>Android (see <a href="android.php">dedicated page</a>)</li>
+  <li>BlackBerry 10/BlackBerry PlayBook</li>
   <li>Unix X11 with Mesa EGL</li>
 </ul>
 
 <p>FreeGLUT ES is provided as a separate library, because OpenGL ES has a distinct,
 incompatible library for each version (e.g. -lGLESv1_CM and -lGLESv2).</p>
+
+<p>When compiled for OpenGL ES 2.0, it is possible to use OpenGL ES 3.0 and higher if the device or
+driver supports it by calling <code>glutInitContextVersion(3.0, 0.0)</code> before creating a window.</p>
 
 <p>The following explains how to use FreeGLUT ES under Mesa EGL.</p>
 

--- a/freeglut/web-src/docs/install.php
+++ b/freeglut/web-src/docs/install.php
@@ -48,6 +48,8 @@ make install
 
 <p>For Android, please see the dedicated <a href="android.php">Android page</a>.</p>
 
+<p>For BlackBerry support, please see <code>README.blackberry</code> in the project source code.</p>
+
 <p>For OpenGL ES support (1.x and 2.x), please see the
 dedicated <a href="gles.php">GLES page</a>.</p>
 

--- a/freeglut/web-src/index.php
+++ b/freeglut/web-src/index.php
@@ -32,8 +32,8 @@ generateHeader($_SERVER['PHP_SELF']);
 
 <div class="textheader"><a name="download"></a>Help out!</div>
 <p>FreeGLUT 3.0 is in active development, and will feature ports to
-Android and BB10 as well as a host of other enhancements. We are looking
-for developers to help out with further work on the Android and BB10
+Android and BlackBerry 10 as well as a host of other enhancements. We are looking
+for developers to help out with further work on the Android and BlackBerry 10
 ports. Furthermore, ports to Cocoa/Carbon on OSX, and maybe even Wayland
 are planned, along with some enhancements to the API and implementation.
 See <a href="progress.php">here</a> for an overview of the major points
@@ -54,7 +54,7 @@ mailing list.</p>
 
 <div class="indent">
 	<div class="textheader">Testing Releases</div>
-    <p>The ports to Andriod and BB10 as well as other API and
+    <p>The ports to Android and BlackBerry 10 as well as other API and
     implementation enhancements (e.g., move to CMake build system, VBO
     and shader support for geometry) are currently only available in
     trunk. Feel free to test by downloading a <a

--- a/freeglut/web-src/progress.php
+++ b/freeglut/web-src/progress.php
@@ -20,13 +20,13 @@ mailing list to discuss your plans, and get cracking!</p>
 <table>
 <tr>
 <th>Feature</th><th>Status</th><th>Milestone</th></tr>
-<tr><td>Android port</td><td>Basic but complete functionality by Sylvain
-Beucler, but there are <a href=docs/android.php#roadmap>todo
+<tr><td>Android port</td><td>Basic but complete functionality by <a href="http://www.beuc.net/">Sylvain
+Beucler</a>, but there are <a href=docs/android.php#roadmap>todo
 points</a></td><td>Basic functionality as is now done: 3.0. Future
 enhancements: 3.0 or later.</td></tr>
 
-<tr><td>Blackberry OS 10 port</td><td>Basic but complete functionality
-by Vinnie Simonetti.</td><td>Basic functionality as is now done: 3.0. Future
+<tr><td>BlackBerry 10 port</td><td>Basic but complete functionality
+by <a href="https://github.com/rcmaniac25">Vinnie Simonetti</a>.</td><td>Basic functionality as is now done: 3.0. Future
 enhancements: 3.0 or later.</td></tr>
 
 <tr><td>10bit display formats</td><td>GLUT supports that but FreeGLUT
@@ -74,7 +74,7 @@ value) after each token are ignored. This is a significant way in which
 FreeGLUT is not compatible with GLUT. Could be a nice project for
 someone who want to become familiar with the intricacies of requesting
 specific display formats on at least one of the various window servers
-(Windows, X11 and Android/EGL at the
+(Windows, X11 and Android/BlackBerry 10/EGL at the
 moment).</td><td>Undecided</td></tr>
 </table>
 </p>


### PR DESCRIPTION
Changed API reference for Android to Mobile, since app status and context apply to mobile platforms primarily.
Fixed missing < ul > in API doc causing everything after the formally-Android section to be indented.
