### PR TITLE
Avoid invalid stack read

### DIFF
--- a/freeglut/freeglut/src/x11/fg_window_x11.c
+++ b/freeglut/freeglut/src/x11/fg_window_x11.c
@@ -137,7 +137,7 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
     XEvent eventReturnBuffer; /* return buffer required for a call */
     unsigned long mask;
     unsigned int current_DisplayMode = fgState.DisplayMode ;
-    XConfigureEvent fakeEvent = {0};
+    XEvent fakeEvent = {0};
 
     /* Save the display mode if we are creating a menu window */
     if( window->IsMenu && ( ! fgStructure.MenuContext ) )
@@ -247,14 +247,14 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
     /* Fake configure event to force viewport setup
      * even with no window manager.
      */
-    fakeEvent.type = ConfigureNotify;
-    fakeEvent.display = fgDisplay.pDisplay.Display;
-    fakeEvent.window = window->Window.Handle;
-    fakeEvent.x = x;
-    fakeEvent.y = y;
-    fakeEvent.width = w;
-    fakeEvent.height = h;
-    XPutBackEvent(fgDisplay.pDisplay.Display, (XEvent*)&fakeEvent);
+    fakeEvent.xconfigure.type = ConfigureNotify;
+    fakeEvent.xconfigure.display = fgDisplay.pDisplay.Display;
+    fakeEvent.xconfigure.window = window->Window.Handle;
+    fakeEvent.xconfigure.x = x;
+    fakeEvent.xconfigure.y = y;
+    fakeEvent.xconfigure.width = w;
+    fakeEvent.xconfigure.height = h;
+    XPutBackEvent(fgDisplay.pDisplay.Display, &fakeEvent);
 
     /*
      * The GLX context creation, possibly trying the direct context rendering


### PR DESCRIPTION
XPutBackEvent copies an XEvent internally, so the pointer passed in must
point to an actual XEvent object, not an XConfigureEvent, which is smaller.
