### PR TITLE
Futureproof: EGL 1.5 support, OpenGL ES 3.1 support

### DIFF
--- a/freeglut/freeglut/README.blackberry
+++ b/freeglut/freeglut/README.blackberry
@@ -6,7 +6,7 @@
 #   $ source /absolute/path/to/the/bbndk/bbndk-env.sh
 #   $ mkdir build
 #   $ cd build
-#   $ cmake .. -DCMAKE_TOOLCHAIN_FILE="../blackberry.toolchain.cmake" -DBLACKBERRY_ARCHITECTURE=arm -DFREEGLUT_GLES2=ON -DFREEGLUT_BUILD_DEMOS=NO -DCMAKE_VERBOSE_MAKEFILE=TRUE -G "Eclipse CDT4 - Unix Makefiles"
+#   $ cmake .. -DCMAKE_TOOLCHAIN_FILE="../blackberry.toolchain.cmake" -DBLACKBERRY_ARCHITECTURE=arm -DFREEGLUT_GLES=ON -DFREEGLUT_BUILD_DEMOS=NO -DCMAKE_VERBOSE_MAKEFILE=TRUE -G "Eclipse CDT4 - Unix Makefiles"
 #   $ make -j8
 #
 #  Usage Mac:
@@ -16,6 +16,8 @@
 #   > /absolute/path/to/the/bbndk/bbndk-env.bat
 #   > mkdir build
 #   > cd build
-#   > cmake .. -DCMAKE_TOOLCHAIN_FILE="../blackberry.toolchain.cmake" -DBLACKBERRY_ARCHITECTURE=arm -DFREEGLUT_GLES2=ON -DFREEGLUT_BUILD_DEMOS=NO -DCMAKE_VERBOSE_MAKEFILE=TRUE -G "Eclipse CDT4 - Unix Makefiles"
+#   > cmake .. -DCMAKE_TOOLCHAIN_FILE="../blackberry.toolchain.cmake" -DBLACKBERRY_ARCHITECTURE=arm -DFREEGLUT_GLES=ON -DFREEGLUT_BUILD_DEMOS=NO -DCMAKE_VERBOSE_MAKEFILE=TRUE -G "Eclipse CDT4 - Unix Makefiles"
 #   > make -j8
 #
+
+To change which version of OpenGL to use, call glutInitContextVersion(1, 0) for OpenGL ES 1.x, glutInitContextVersion(2, 0) for OpenGL ES 2.0, or glutInitContextVersion(3, 0) for OpenGL ES 3.0.

--- a/freeglut/freeglut/src/blackberry/fg_window_blackberry.c
+++ b/freeglut/freeglut/src/blackberry/fg_window_blackberry.c
@@ -61,7 +61,7 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
     int screenFormat = SCREEN_FORMAT_RGBA8888; //Only SCREEN_FORMAT_RGBA8888 and SCREEN_FORMAT_RGB565 are supported. See fg_window_egl for more info
     int configAttri;
 #define EGL_QUERY_COMP(att, comp) (eglGetConfigAttrib(fgDisplay.pDisplay.egl.Display, window->Window.pContext.egl.Config, att, &configAttri) == GL_TRUE && (configAttri comp))
-    if(EGL_QUERY_COMP(EGL_ALPHA_SIZE, <= 0) && EGL_QUERY_COMP(EGL_RED_SIZE, <= 5) &&
+    if (EGL_QUERY_COMP(EGL_ALPHA_SIZE, <= 0) && EGL_QUERY_COMP(EGL_RED_SIZE, <= 5) &&
             EGL_QUERY_COMP(EGL_GREEN_SIZE, <= 6) && EGL_QUERY_COMP(EGL_BLUE_SIZE, <= 5)) {
         screenFormat = SCREEN_FORMAT_RGB565;
     }
@@ -69,11 +69,17 @@ void fgPlatformOpenWindow( SFG_Window* window, const char* title,
 
     /* Set window properties */
     int orientation = atoi(getenv("ORIENTATION"));
-#ifdef GL_ES_VERSION_2_0
-    int screenUsage = SCREEN_USAGE_OPENGL_ES2 | SCREEN_USAGE_ROTATION;
-#elif GL_VERSION_ES_CM_1_0 || GL_VERSION_ES_CL_1_0 || GL_VERSION_ES_CM_1_1 || GL_VERSION_ES_CL_1_1
-    int screenUsage = SCREEN_USAGE_OPENGL_ES1 | SCREEN_USAGE_ROTATION;
+    int screenUsage = SCREEN_USAGE_ROTATION;
+#ifdef SCREEN_USAGE_OPENGL_ES3
+    if (fgState.MajorVersion >= 3) {
+        screenUsage |= SCREEN_USAGE_OPENGL_ES3;
+    } else
 #endif
+    if (fgState.MajorVersion >= 2) {
+        screenUsage |= SCREEN_USAGE_OPENGL_ES2;
+    } else {
+        screenUsage |= SCREEN_USAGE_OPENGL_ES1;
+    }
 #if !defined(__X86__) && !defined(__PLAYBOOK__)
     screenUsage |= SCREEN_USAGE_DISPLAY; // Physical device copy directly into physical display
 #endif

--- a/freeglut/freeglut/src/egl/fg_init_egl.c
+++ b/freeglut/freeglut/src/egl/fg_init_egl.c
@@ -39,7 +39,7 @@ void fghPlatformInitializeEGL()
 
   FREEGLUT_INTERNAL_ERROR_EXIT(fgDisplay.pDisplay.egl.Display != EGL_NO_DISPLAY,
 			       "No display available", "fgPlatformInitialize");
-  if (eglInitialize(fgDisplay.pDisplay.egl.Display, NULL, NULL) != EGL_TRUE)
+  if (eglInitialize(fgDisplay.pDisplay.egl.Display, &fgDisplay.pDisplay.egl.MajorVersion, &fgDisplay.pDisplay.egl.MinorVersion) != EGL_TRUE)
     fgError("eglInitialize: error %x\n", eglGetError());
 
 # ifdef GL_VERSION_1_1  /* or later */
@@ -59,6 +59,8 @@ void fghPlatformCloseDisplayEGL()
   if (fgDisplay.pDisplay.egl.Display != EGL_NO_DISPLAY) {
     eglTerminate(fgDisplay.pDisplay.egl.Display);
     fgDisplay.pDisplay.egl.Display = EGL_NO_DISPLAY;
+    fgDisplay.pDisplay.egl.MajorVersion = 0;
+    fgDisplay.pDisplay.egl.MinorVersion = 0;
   }
 }
 

--- a/freeglut/freeglut/src/egl/fg_internal_egl.h
+++ b/freeglut/freeglut/src/egl/fg_internal_egl.h
@@ -35,6 +35,8 @@ struct tagSFG_PlatformDisplayEGL
 {
   /* Used to initialize and deinitialize EGL */
   EGLDisplay          Display;
+  EGLint              MajorVersion;
+  EGLint              MinorVersion;
 };
 
 


### PR DESCRIPTION
- Future-proof implementation for EGL 1.5 and OpenGL ES 3.1 now that official specs have been released.
- glutInitContextVersion's minor version can be used for more exact OpenGL ES version picking, if EGL 1.5 is in use.
- Updated BlackBerry to support latest changes to FreeGLUT to work with glutInitContextVersion instead of compile version.
