### PR TITLE
Add fg_version.h for building without cmake

### DIFF
--- a/freeglut/freeglut/CMakeLists.txt
+++ b/freeglut/freeglut/CMakeLists.txt
@@ -18,6 +18,8 @@ set(VERSION_MAJOR 3)
 set(VERSION_MINOR 0)
 set(VERSION_PATCH 0)
 
+# Update fg_version.h to match the versions number here in cmake
+CONFIGURE_FILE(src/fg_version.h.in src/fg_version.h)
 
 # FREEGLUT_BUILD_SHARED_LIBS is already a standard CMake variable, but we need to
 # re-declare it here so it will show up in the GUI.

--- a/freeglut/freeglut/src/fg_internal.h
+++ b/freeglut/freeglut/src/fg_internal.h
@@ -32,6 +32,8 @@
 #    include "config.h"
 #endif
 
+#include "fg_version.h"
+
 /* Freeglut is intended to function under all Unix/X11 and Win32 platforms. */
 /* XXX: Don't all MS-Windows compilers (except Cygwin) have _WIN32 defined?
  * XXX: If so, remove the first set of defined()'s below.

--- a/freeglut/freeglut/src/fg_version.h
+++ b/freeglut/freeglut/src/fg_version.h
@@ -1,0 +1,47 @@
+/*
+ * fg_version.h
+ *
+ * The freeglut library private include file.
+ *
+ * Copyright (c) 1999-2000 Pawel W. Olszta. All Rights Reserved.
+ * Written by Pawel W. Olszta, <olszta@sourceforge.net>
+ * Creation date: Thu Dec 2 1999
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * PAWEL W. OLSZTA BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef  FREEGLUT_VERSION_H
+#define  FREEGLUT_VERSION_H
+
+/* Ordinarily it's cmake's job to update fg_version.h,
+ * edit CMakeLists.txt rather than this file directly.
+ */
+
+#ifndef VERSION_MAJOR
+#define VERSION_MAJOR 3
+#endif
+
+#ifndef VERSION_MINOR
+#define VERSION_MINOR 0
+#endif
+
+#ifndef VERSION_PATCH
+#define VERSION_PATCH 0
+#endif
+
+#endif

--- a/freeglut/freeglut/src/fg_version.h.in
+++ b/freeglut/freeglut/src/fg_version.h.in
@@ -1,0 +1,47 @@
+/*
+ * fg_version.h
+ *
+ * The freeglut library private include file.
+ *
+ * Copyright (c) 1999-2000 Pawel W. Olszta. All Rights Reserved.
+ * Written by Pawel W. Olszta, <olszta@sourceforge.net>
+ * Creation date: Thu Dec 2 1999
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * PAWEL W. OLSZTA BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef  FREEGLUT_VERSION_H
+#define  FREEGLUT_VERSION_H
+
+/* Ordinarily it's cmake's job to update fg_version.h,
+ * edit CMakeLists.txt rather than this file directly.
+ */
+
+#ifndef VERSION_MAJOR
+#define VERSION_MAJOR @VERSION_MAJOR@
+#endif
+
+#ifndef VERSION_MINOR
+#define VERSION_MINOR @VERSION_MINOR@
+#endif
+
+#ifndef VERSION_PATCH
+#define VERSION_PATCH @VERSION_PATCH@
+#endif
+
+#endif


### PR DESCRIPTION
As discussed by email, the proposal is for cmake to generate fg_version.h which will provide the version number, unless already specified by the build system.  This allows for various other build systems to be used without managing the version number manually in each of them.
