### PR TITLE
Tidy-up: Include config.h via fg_internal.h only

### DIFF
--- a/freeglut/freeglut/src/fg_input_devices.c
+++ b/freeglut/freeglut/src/fg_input_devices.c
@@ -28,10 +28,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
-#    include "config.h"
-#endif
-
 #include <GL/freeglut.h>
 #include "fg_internal.h"
 

--- a/freeglut/freeglut/src/x11/fg_input_devices_x11.c
+++ b/freeglut/freeglut/src/x11/fg_input_devices_x11.c
@@ -30,10 +30,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
-#    include "config.h"
-#endif
-
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
 


### PR DESCRIPTION
I came across these extraneous-looking inclusions incidentally.  My main thought experiment is if fg_internal.h could or ought to auto-detect the autoconf/cmake variables such as HAVE_SYS_TYPES_H based on platform and/or compiler macros.
