### PR TITLE
Add "FGAPI" before all core instanciation  of Interface functions of Freeglut v3.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,126 @@ if (POLICY CMP0072)
     cmake_policy(SET CMP0072 NEW)
 endif()
 
+# NOTE :	Added at 2024/03/16, on Windows, you can choose many "free" compilers to generate Freeglut.
+#			All of these "free" compilers are installed on "specific" directory, same like MSVC (not in "/usr/bin" ... -))
+#			This addon, is mandatory to determine which compiler or devlopment environment is used and parameter this.
+#   WARNING : 		On my system, to choose "good" directories of binaries, include files and libraries, I decide to parameter
+#					many environment variables (system level) to point to these (because version's num defined directories ... GRRR) : 
+#									KIT_WIN_NUM  		valued at time 		10.0.22621.0
+#									KIT_WIN_VERSION  	valued at time 		10
+#									VS_NUM 				valued at time		14.39.33519
+#									VS_VERSION 			valued at time		2022
+#									CLANG_VERSION 		valued at time		18.1.3
+#									LLVM 				valued at time		"C:\Program Files (x86)\LLVM"  (only for command file)
+#									LLVM64 				valued at time		"C:\Program Files\LLVM"        (only for command file)
+#					These values can changed after upgrade of CLANG and Visual Studio 2022 Community on Windows 11.
+#					The change only on these variables permit update with "smoothly" impact...  (recently CLANG 18.1.2 to 18.1.3)
+#					I use many $ENV{xxxxx} in this parameter file to dereference/translate environment variable.
+#					Examine lines 72-73 or 78-79, nothing change after upgrade. Simply.
+#					Another solution can be : use many parameters during run of "cmake" with "-Dxxxxxxx=yyyyy" on command line. Very long line ...
+#					But, in this case, it is mandatory to exchange in this parameter file all the call function $ENV{xxxxx} by ${xxxxx}.
+#   WARNING(2): 	To parameter good configuration of CLANG and CYGWIN in this parameter file, I decide to use another environment 
+#					variables set by "-Dvar=value" during run of generation by cmake :
+#							 CLANG_BUILD_TOOL   valued by 	MSYS2 to generate MinGW32 / MinGW64 targets included in package MSYS2, 
+#														or  WINLIB to generate MinGW32 / MinGW64 targets included in package WINLIBS, 
+#														or  VC to generate Visual C/C++ + Development Kit Windows targets
+#							 CLANG_BUILD_ARCH   valued by 	x86 to generate 32 bits targets, x64 (or nothing) to generate 64 bits targets
+#							 CYGWIN_BUILD_ARCH  valued by 	x86 to generate 32 bits targets, x64 (or nothing) to generate 64 bits targets
+# 					Maybe two last variable can be "mutualized" in only one, but for best comprehension, I decide to conserve distinction. 
+#	WARNING(3) 		To suppress "hard naming" of directories of "root" compilers or devlopment packages in this file, it's possible to
+#					design it by another environment variables. I create these variables, but in the parameter file of cmake, I don't use.
+#					If you want, I can used it. What you think about this ? Interesting or not ? (example : var BORLANDC refer "C:\BCC55")
+#	Conclusion : This is my proposition to adapt each configuration of compilers. What you think about this ?	
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+# 	If you want use "Clang" on Unix/Linux or Mac OS, maybe you must define good instructions here ?
+  IF (${CLANG_BUILD_TOOL} MATCHES MSYS2)
+    IF (${CLANG_BUILD_ARCH} MATCHES x86)
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/msys64/mingw32/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 32 bits - MSYS2.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+      include_directories(BEFORE "C:/msys64/mingw32/include") 
+      link_directories(BEFORE "C:/msys64/mingw32/lib")
+    ELSE()
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/msys64/mingw64/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 64 bits - MSYS2.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+      include_directories(BEFORE "C:/msys64/mingw64/include") 
+      link_directories(BEFORE "C:/msys64/mingw64/lib")
+    ENDIF()
+  ELSEIF(${CLANG_BUILD_TOOL} MATCHES WINLIB)
+    IF (${CLANG_BUILD_ARCH} MATCHES x86)
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/mingw32/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 32 bits - Winlibs.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+      include_directories(BEFORE "C:/mingw32/i686-w64-mingw32/include" "C:/mingw32/include" ) 
+      link_directories(BEFORE "C:/mingw32/i686-w64-mingw32/lib" )
+    ELSE()
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/mingw64/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 64 bits - Winlibs.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+      include_directories(BEFORE "C:/mingw64/x86_64-w64-mingw32/include" "C:/mingw64/include" ) 
+      link_directories(BEFORE "C:/mingw64/x86_64-w64-mingw32/lib" )
+    ENDIF()
+  ELSEIF(${CLANG_BUILD_TOOL} MATCHES VC)
+    IF (${CLANG_BUILD_ARCH} MATCHES x86)
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/Program Files (x86)/LLVM/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 32 bits - Visual C/C++.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+      include_directories(BEFORE "C:/Program Files (x86)/LLVM/lib/clang/$ENV{CLANG_VERSION}/include" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/um" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/shared" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/ucrt" "C:/Program Files/Microsoft Visual Studio/$ENV{VS_VERSION}/Community/VC/Tools/MSVC/$ENV{VS_NUM}/include") 
+      link_directories(BEFORE "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Lib/$ENV{KIT_WIN_NUM}/um/x86" "C:/Program Files (x86)/LLVM/lib/clang/$ENV{CLANG_VERSION}/lib/windows" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Lib/$ENV{KIT_WIN_NUM}/ucrt/x86" "C:/Program Files/Microsoft Visual Studio/$ENV{VS_VERSION}/Community/VC/Tools/MSVC/$ENV{VS_NUM}/lib/x86")
+    ELSE()
+	  SET(CMAKE_FIND_ROOT_PATH  "C:/Program Files/LLVM/bin" )
+      MESSAGE("Clang - Setting CLANG flags for compile and link to generate Freeglut 64 bits - Visual C/C++.")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+      include_directories(BEFORE "C:/Program Files/LLVM/lib/clang/$ENV{CLANG_VERSION}/include" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/um" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/shared" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Include/$ENV{KIT_WIN_NUM}/ucrt" "C:/Program Files/Microsoft Visual Studio/$ENV{VS_VERSION}/Community/VC/Tools/MSVC/$ENV{VS_NUM}/include") 
+      link_directories(BEFORE "C:/Program Files/LLVM/lib/clang/$ENV{CLANG_VERSION}/lib/windows" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Lib/$ENV{KIT_WIN_NUM}/um/x64" "C:/Program Files (x86)/Windows Kits/$ENV{KIT_WIN_VERSION}/Lib/$ENV{KIT_WIN_NUM}/ucrt/x64" "C:/Program Files/Microsoft Visual Studio/$ENV{VS_VERSION}/Community/VC/Tools/MSVC/$ENV{VS_NUM}/lib/x64")
+    ENDIF()
+  ENDIF()	
+elseif (CYGWIN)
+  SET(CMAKE_FIND_ROOT_PATH  "C:/cygwin64/bin" )
+  # choice to determine which compilers to use for C and C++, 32 or 64 bits
+  #	Added at 2024/03/29, to determine which compiler or devlopment environment is used with CYGWIN
+  IF (${CYGWIN_BUILD_ARCH} MATCHES x86)
+	SET(CMAKE_C_COMPILER "i686-w64-mingw32-gcc.exe" )
+	# SET(CMAKE_CXX_COMPILER "i686-w64-mingw32-g++.exe" )
+	SET(CMAKE_RC_COMPILER "i686-w64-mingw32-windres.exe" )
+	message(STATUS "CYGWIN - Setting GCC flags to compile and link to generate Freeglut with i686-w64-mingw32-gcc.exe compiler.")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32 -D_WIN32")
+	set(CMAKE_LINK_FLAGS "${CMAKE_LINK_FLAGS} -mwindows")
+	include_directories(BEFORE "C:/cygwin64/usr/i686-w64-mingw32/sys-root/mingw/include" )
+	link_directories(BEFORE "C:/cygwin64/usr/i686-w64-mingw32/sys-root/mingw/lib" )
+  ELSE()
+	SET(CMAKE_C_COMPILER "x86_64-w64-mingw32-gcc.exe" )
+	# SET(CMAKE_CXX_COMPILER "x86_64-w64-mingw32-g++.exe" )
+	SET(CMAKE_RC_COMPILER "x86_64-w64-mingw32-windres.exe" )
+	message(STATUS "CYGWIN - Setting GCC flags to compile and link to generate Win32 application with x86_64-w64-mingw32-gcc.exe compiler.")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -D_WIN32")
+	set(CMAKE_LINK_FLAGS "${CMAKE_LINK_FLAGS} -mwindows")
+	include_directories(BEFORE "C:/cygwin64/usr/x86_64-w64-mingw32/sys-root/mingw/include" )
+	link_directories(BEFORE "C:/cygwin64/usr/x86_64-w64-mingw32/sys-root/mingw/lib" )
+  endif()
+elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  MESSAGE("GNU C Compiler used to generation of Freeglut.")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Intel")
+  MESSAGE("Intel Compiler used to generation of Freeglut.")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  MESSAGE("MSVC [ot Visual C/C++] Compiler used to generation of Freeglut.")
+elseif (BORLAND)
+  MESSAGE("Borland C/C++ Compiler used to generation of Freeglut 32 bits.")
+elseif (CMAKE_C_COMPILER_ID MATCHES "OpenWatcom")
+  MESSAGE("OpenWatcom C/C++ Compiler used to generation of Freeglut 32 bits.")
+  #  Précision : "wcc386" option "-aa" allow non const initializers for local aggregates or unions. Mandatory.
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -aa")
+  include_directories(BEFORE "C:/WATCOM/h/nt" "C:/WATCOM/h" )
+  #  Précision : "wlink" need search library "freeglut.lib" or "freeglutd.lib" in directory ${PROJECT_BINARY_DIR}/lib
+  link_directories(BEFORE "C:/WATCOM/lib386/nt" "${PROJECT_BINARY_DIR}/lib" )
+endif()
+
 # for multiarch LIBDIR support (requires cmake>=2.8.8)
-INCLUDE(GNUInstallDirs)
+#   Modified at 2024/03/13 - added new test to limit avertissement (Warning) with Open Watcom by example.
+IF(CMAKE_COMPILER_IS_GNUCC)
+  INCLUDE(GNUInstallDirs)
+ENDIF()
 
 # NOTE: On Windows and Cygwin, the dll's are placed in the
 # CMAKE_RUNTIME_OUTPUT_DIRECTORY, while their corresponding import
@@ -155,11 +273,35 @@ IF(WIN32)
     IF (MSVC AND NOT CMAKE_CL_64)
         # .def file only for 32bit Windows builds (TODO: MSVC only right
         # now, needed for any other Windows platform?)
+		#  Added "def file" is mandatory only for Digital Mars Compiler. I use ${CMAKE_BINARY_DIR}/freeglut_dmc.def
+		#  		Syntax of the def file is very specific to this compiler.
+		#		WARNING : the name of DLL appear at first line of the def file. But with difference beetween Debug and Release name of 
+		#       the DLL, I must modify the first line "at the hand". But I don't use CMAKE to generate DMC version of Freeglut, only Code::Blocks
+		#		then, this comment is present only for general information to devlopers. I constraint CB to search this file by configuration. 
         LIST(APPEND FREEGLUT_SRCS
             ${CMAKE_BINARY_DIR}/freeglutdll.def # generated below from src/freeglutdll.def.in
         )
     ENDIF()
-
+	#	Modified at 2024/03/16, add this test to permit CYGWIN to generate Win32 application (not Unix/X11)
+ELSEIF(CYGWIN)
+    LIST(APPEND FREEGLUT_SRCS
+        src/mswin/fg_cursor_mswin.c
+        src/mswin/fg_display_mswin.c
+        src/mswin/fg_ext_mswin.c
+        src/mswin/fg_gamemode_mswin.c
+        src/mswin/fg_init_mswin.c
+        src/mswin/fg_internal_mswin.h
+        src/mswin/fg_input_devices_mswin.c
+        src/mswin/fg_joystick_mswin.c
+        src/mswin/fg_main_mswin.c
+        src/mswin/fg_menu_mswin.c
+        src/mswin/fg_spaceball_mswin.c
+        src/mswin/fg_state_mswin.c
+        src/mswin/fg_structure_mswin.c
+        src/mswin/fg_window_mswin.c
+		src/mswin/fg_cmap_mswin.c
+        ${CMAKE_BINARY_DIR}/freeglut.rc # generated below from freeglut.rc.in
+    )
 ELSEIF(ANDROID OR BLACKBERRY)
     # BlackBerry and Android share some similar design concepts and ideas, as with many mobile devices.
     # As such, some classes can be shared between the two. XXX: Possibly rename shareable classes to
@@ -267,6 +409,8 @@ IF(FREEGLUT_GLES OR FREEGLUT_WAYLAND)
 ENDIF()
 
 INCLUDE(CheckIncludeFiles)
+#    Added at 2024/03/10 - Bug with MinGW32/MinGW64 of CYGWIN (assimiled at UNIX by CMAKE ???) 
+IF(NOT CYGWIN)
 IF(UNIX AND NOT(ANDROID OR BLACKBERRY OR FREEGLUT_WAYLAND))
     FIND_PACKAGE(X11 REQUIRED)
     INCLUDE_DIRECTORIES(${X11_X11_INCLUDE_PATH})
@@ -286,6 +430,7 @@ IF(UNIX AND NOT(ANDROID OR BLACKBERRY OR FREEGLUT_WAYLAND))
     ELSE()
         MESSAGE(WARNING "Missing X11's XInput2.h (X11/extensions/XInput2.h)")
     ENDIF()
+ENDIF()
 ENDIF()
 
 # FreeBSD and NetBSD joystick code uses libusbhid
@@ -387,18 +532,29 @@ ENDIF()
 
 # lib m for math, not needed on windows
 IF (NOT WIN32)
-    # For compilation:
-    LIST(APPEND LIBS m)
-    # For CHECK_FUNCTION_EXISTS:
-    LIST(APPEND CMAKE_REQUIRED_LIBRARIES m)
+#	Added at I use CYGWIN only with MinGW32/MinGW64, not for compatibility Unix/X11 on Windows.
+#	WARNING : Note, It's not possible to generate Freeglut with CYGWIN / X11 because libraries of extensions XFree86 don't exist,
+#				like Xxf86vm !!! 
+	IF (NOT CYGWIN)
+      # For compilation:
+      LIST(APPEND LIBS m)
+      # For CHECK_FUNCTION_EXISTS:
+      LIST(APPEND CMAKE_REQUIRED_LIBRARIES m)
+	ENDIF()
 ENDIF()
 
 IF(WIN32)
     # hide insecure CRT warnings, common practice
     ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
-    IF(MSVC)
-        SET( CMAKE_DEBUG_POSTFIX "d" )
-    ENDIF(MSVC)
+	
+#    Modified at 2014/03/10, why this POSTFIX is not positioned with configuration "DEBUG" !!! ?
+#    Proposition : extract this test for it operate most generally on all platforms, not only WIN32 or CYGWIN
+#    If I propose that, it's for distinguish Debug and Release version of Freeglut on "same" directory /bin and /lib 
+#	 used by CMAKE (see below at the beginning of this file).
+#		What you think about this ?
+	IF(CMAKE_BUILD_TYPE MATCHES Debug)
+		SET( CMAKE_DEBUG_POSTFIX "d" )
+	ENDIF()
 
     IF(NOT(MSVC_VERSION LESS "1600"))
     # minimum requirement for WM_TOUCH device
@@ -413,7 +569,15 @@ IF(WIN32)
         ADD_DEFINITIONS(-D_WIN32_WINNT=0x0500)
         ADD_DEFINITIONS(-DWINVER=0x0500)
     ENDIF()
-
+#   Added, CYGWIN don't define variable _WIN32, and CMAKE ... don't range CYGWIN in category of WIN32 platform ...  
+ELSEIF(CYGWIN)
+#    Modified at 2014/03/10, why this POSTFIX is not positioned with configuration "DEBUG" !!! ?
+	IF(CMAKE_BUILD_TYPE MATCHES Debug)
+		SET( CMAKE_DEBUG_POSTFIX "d" )
+	ENDIF()
+    # minimum requirement for spaceball device
+    ADD_DEFINITIONS(-D_WIN32_WINNT=0x0501)
+    ADD_DEFINITIONS(-DWINVER=0x0501)
 ENDIF()
 
 IF(CMAKE_COMPILER_IS_GNUCC)
@@ -422,6 +586,18 @@ IF(CMAKE_COMPILER_IS_GNUCC)
     # not setting -ansi as EGL/KHR headers doesn't support it
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
   ENDIF()
+  #     Added, setting "good" options to differentiate Debug or Release generation with GCC compiler.
+  #     Verify if these options are the same on Linux, Mac OS, OS X and others platforms ? Correct on Windows platform.
+  #     If not, add a test on platform Windows (and compatible platforms) before this addon.
+  add_compile_options(
+	$<$<CONFIG:DEBUG>:-g3>
+	$<$<CONFIG:DEBUG>:-Og>
+	$<$<CONFIG:RELEASE>:-O3>
+  )
+
+  add_compile_definitions(
+	$<$<CONFIG:DEBUG>:DEBUG>
+  )
 ENDIF(CMAKE_COMPILER_IS_GNUCC)
 
 IF(ANDROID)
@@ -487,6 +663,9 @@ IF(WIN32)
         # .def file only for 32bit Windows builds with Visual Studio
         CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/freeglutdll.def.in ${CMAKE_BINARY_DIR}/freeglutdll.def)
     ENDIF()
+#   Added at 2024/03/21 - CYGWIN not recognize by test IF(WIN32) ... and I use MinGW32/MinGW64 on CYGWIN : "rc" file are authorized.
+ELSEIF(CYGWIN)
+    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/freeglut.rc.in ${CMAKE_BINARY_DIR}/freeglut.rc)
 ENDIF()
 
 IF(FREEGLUT_BUILD_SHARED_LIBS)
@@ -503,6 +682,14 @@ IF(WIN32)
         SET(LIBNAME glut)
     ENDIF()
 
+#	Modified at 2024/03/10, added this DEFINITION to compilers (not MSVC) because build demos crash 
+	IF(${CMAKE_BUILD_TYPE} MATCHES Release)
+	    IF(MSVC)
+			ADD_DEFINITIONS(-DNDEBUG)
+		ELSE()
+			ADD_DEFINITIONS(/DNDEBUG)
+		ENDIF()
+	ENDIF()
     LIST(APPEND LIBS winmm gdi32)
     IF(FREEGLUT_BUILD_SHARED_LIBS)
         TARGET_COMPILE_DEFINITIONS(freeglut PRIVATE FREEGLUT_EXPORTS)
@@ -522,6 +709,30 @@ IF(WIN32)
             ELSE()
                 SET_TARGET_PROPERTIES(freeglut_static PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
             ENDIF()
+        ENDIF()
+    ENDIF()
+	#	Modified at 2024/03/16, add this test to permit CYGWIN to generate Win32 application (not Unix)
+ELSEIF(CYGWIN)
+    IF(FREEGLUT_REPLACE_GLUT)
+        SET(LIBNAME glut)
+    ENDIF()
+#	Modified at 2024/03/10, added this DEFINITIONS to compiler because build demos crash 
+	IF(CMAKE_BUILD_TYPE MATCHES Release)
+	    IF(MSVC)
+			ADD_DEFINITIONS(-DNDEBUG)
+		ELSE()
+			ADD_DEFINITIONS(/DNDEBUG)
+		ENDIF()
+	ENDIF()
+	LIST(APPEND LIBS glu32 opengl32 winmm gdi32 user32)
+    IF(FREEGLUT_BUILD_SHARED_LIBS)
+        TARGET_COMPILE_DEFINITIONS(freeglut PRIVATE FREEGLUT_EXPORTS)
+        SET_TARGET_PROPERTIES(freeglut PROPERTIES OUTPUT_NAME ${LIBNAME})
+    ENDIF()
+    IF(FREEGLUT_BUILD_STATIC_LIBS)
+        TARGET_COMPILE_DEFINITIONS(freeglut_static PUBLIC FREEGLUT_STATIC)
+        IF(FREEGLUT_REPLACE_GLUT)
+            SET_TARGET_PROPERTIES(freeglut_static PROPERTIES OUTPUT_NAME ${LIBNAME})
         ENDIF()
     ENDIF()
 ELSE()
@@ -624,6 +835,7 @@ endif()
 
 # lib m for math, not needed on windows
 IF (NOT WIN32)
+#   Added at 2024/03/10 - Note : fortunatly, library "m" exist with MinGW32/MinGW64 of CYGWIN, and also with portability.
     LIST(APPEND DEMO_LIBS m)
 ENDIF()
 
@@ -632,16 +844,32 @@ MACRO(ADD_DEMO name)
         IF(FREEGLUT_BUILD_SHARED_LIBS)
             ADD_EXECUTABLE(${name} ${ARGN})
             TARGET_LINK_LIBRARIES(${name} ${DEMO_LIBS} freeglut)
-            IF(WIN32 AND MSVC)
-                SET_TARGET_PROPERTIES(${name} PROPERTIES DEBUG_POSTFIX d)
+		# 	Modified at 2014/03/10 - Why this test is not conditioned by configuration DEBUG, seriously ... !!!
+            IF(WIN32)
+				IF(CMAKE_BUILD_TYPE MATCHES Debug)
+					SET_TARGET_PROPERTIES(${name} PROPERTIES DEBUG_POSTFIX d)
+				ENDIF()
+            ENDIF()
+            IF(CYGWIN)
+				IF(CMAKE_BUILD_TYPE MATCHES Debug)
+					SET_TARGET_PROPERTIES(${name} PROPERTIES DEBUG_POSTFIX d)
+				ENDIF()
             ENDIF()
         ENDIF()
         IF(FREEGLUT_BUILD_STATIC_LIBS)
             ADD_EXECUTABLE(${name}_static ${ARGN})
             TARGET_LINK_LIBRARIES(${name}_static ${DEMO_LIBS} freeglut_static)
-            IF(WIN32 AND MSVC)
-                SET_TARGET_PROPERTIES(${name}_static PROPERTIES DEBUG_POSTFIX d)
-            ENDIF()
+# 	Modified at 2014/03/10 - Why this test is not conditioned by configuration DEBUG, seriously ... !!!
+            IF(WIN32)
+				IF(CMAKE_BUILD_TYPE MATCHES Debug)
+                	SET_TARGET_PROPERTIES(${name}_static PROPERTIES DEBUG_POSTFIX d)
+            	ENDIF()
+			ENDIF()
+            IF(CYGWIN)
+				IF(CMAKE_BUILD_TYPE MATCHES Debug)
+                	SET_TARGET_PROPERTIES(${name}_static PROPERTIES DEBUG_POSTFIX d)
+            	ENDIF()
+			ENDIF()
         ENDIF()
     ENDIF()
 ENDMACRO()
@@ -650,11 +878,14 @@ ADD_DEMO(CallbackMaker   progs/demos/CallbackMaker/CallbackMaker.c)
 ADD_DEMO(Fractals        progs/demos/Fractals/fractals.c)
 ADD_DEMO(Fractals_random progs/demos/Fractals_random/fractals_random.c)
 ADD_DEMO(Lorenz          progs/demos/Lorenz/lorenz.c)
-IF (NOT WIN32)
-    ADD_DEMO(One             progs/demos/One/one.c)
-ELSE()
+IF (WIN32)
     ADD_DEMO(One             progs/demos/One/one.c
                              progs/demos/One/one.rc)
+ELSEIF (CYGWIN)
+    ADD_DEMO(One             progs/demos/One/one.c
+                             progs/demos/One/one.rc)
+ELSE()
+    ADD_DEMO(One             progs/demos/One/one.c)
 ENDIF()
 ADD_DEMO(resizer         progs/demos/resizer/resizer.c)
 ADD_DEMO(multi-touch     progs/demos/multi-touch/multi-touch.c)

--- a/include/GL/freeglut_std.h
+++ b/include/GL/freeglut_std.h
@@ -35,31 +35,6 @@
 /*
  * Under windows, we have to differentiate between static and dynamic libraries
  */
- /*   Added at 2024/04/09
-  *     WARNING by use of _WIN32 on Windows, not all compilers define it by default ...
-  *     __NT__ with OpenWatcom, _WIN32 with GCC, MSVC, CLANG, Pelles C, lcc (?) __WIN32__ with Borland C/C++ defined Windows Operating System
-  *     I sugger use of next test - Reference : https://github.com/cpredef/predef/blob/master/OperatingSystems.md
-  *         (accept many configurations)
-  *
-  *     #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__DMC__) || defined(__NT__) || \
-  *         defined(__WIN32__) || defined(__LCC__)
-  *             #define OS_WIN
-  *     #endif
-  *     (I doubt about __MINGW32__ on Linux (cross compilation) ??)
-  *
-  *     After you can test like #ifdef OS_WIN ... in suitable oode ...
-  *     What decide you about this proposition ?
-  *
-  *     WARNING : in file src\fg_internal.h here the next test about "hosting" on Windows, but Open WATCOM run also on Unix/Linux platform ...
-  *
-  *     #if defined(_MSC_VER) || defined(__WATCOMC__) || defined(__MINGW32__) || defined(__DMC__) || defined(__BORLANDC__) \
-  *      || defined(_WIN32) || defined(_WIN32_WCE) \
-  *      || ( defined(__CYGWIN__) && defined(X_DISPLAY_MISSING) )
-  *     #   define  TARGET_HOST_MS_WINDOWS 1
-  *     #endif
-  *
-  *     Autoconf and Configure need presence of var X_DISPLAY_MISSING, but another build tool like CMAKE ? __CYGWIN__ only ?
-  */
 #ifdef _WIN32
 /* #pragma may not be supported by some compilers.
  * Discussion by FreeGLUT developers suggests that
@@ -72,19 +47,6 @@
  * The default behavior depends on the compiler/platform.
  */
 #   ifndef FREEGLUT_LIB_PRAGMAS
-/*  Added at 2024/04/09 - WARNING this test is insuffisant at date ... I suggest next test
- * #if ( defined(_MSC_VER) || \
- *      defined(__ICL) || \
- *		defined(__MWERKS__) && defined(_WIN32) || \
- *		defined(__BORLANDC__) || \
- *		defined(__DMC__) || \
- *		defined(__POCC__) || \
- *      defined(__WATCOMC__) ) && !defined(_WIN32_WCE)
- *	#       define FREEGLUT_LIB_PRAGMAS 1
- *  #    else
- *  #       define FREEGLUT_LIB_PRAGMAS 0
- *	#endif
- *  What decide you about this proposition ?  */
 #       if ( defined(_MSC_VER) || defined(__WATCOMC__) ) && !defined(_WIN32_WCE)
 #           define FREEGLUT_LIB_PRAGMAS 1
 #       else
@@ -117,7 +79,7 @@
 
 /* Windows shared library (DLL) */
 #   else
-//       Added at 2024/04/08 - LCC don't support "__stdcall" call convention with shared functions ...
+//       Added at 2024/04/08 - LCC don't support "__stdcall" call convention with shared functions of DLL ...
 #if defined(__LCC__)
 #       define FGAPIENTRY
 #else
@@ -256,7 +218,6 @@
  * Steve Baker suggested to make it binary compatible with GLUT:
  */
 
-//     Added at 2024/03/20 -  "|| defined(__BORLANDC__)  || defined(__DMC__) || defined(__LCC__) || defined(__POCC__)"
 #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__WATCOMC__) || defined(__BORLANDC__) || defined(__DMC__) || defined(__LCC__) || defined(__POCC__)
 #   define  GLUT_STROKE_ROMAN               ((void *)0x0000)
 #   define  GLUT_STROKE_MONO_ROMAN          ((void *)0x0001)

--- a/src/fg_callback_macros.h
+++ b/src/fg_callback_macros.h
@@ -1,3 +1,6 @@
+#ifndef HEADER_FD8F5E91BFF0673D
+#define HEADER_FD8F5E91BFF0673D
+
 /*
  * fg_callback_macros.h
  *
@@ -242,13 +245,13 @@ static void fgh##a##FuncCallback( int arg1val, int arg2val, int arg3val, int arg
  * And almost every time the callback setter function can be implemented with these:
  */
 #define IMPLEMENT_CURRENT_WINDOW_CALLBACK_FUNC_2NAME_GLUT_UCALL(a,b)      \
-void FGAPIENTRY glut##a##FuncUcall( FGCB##b##UC callback, FGCBUserData userData ) \
+FGAPI void FGAPIENTRY glut##a##FuncUcall( FGCB##b##UC callback, FGCBUserData userData ) \
 {                                                                         \
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glut"#a"FuncUcall" );             \
     SET_CURRENT_WINDOW_CALLBACK( b );                                     \
 }
 #define IMPLEMENT_CALLBACK_FUNC_2NAME_GLUT_BASE(a,b)                      \
-void FGAPIENTRY glut##a##Func( FGCB##b callback )                         \
+FGAPI void FGAPIENTRY glut##a##Func( FGCB##b callback )                         \
 {                                                                         \
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glut"#a"Func" );                  \
     if( callback )                                                        \
@@ -334,3 +337,5 @@ void FGAPIENTRY glut##a##Func( FGCB##b callback )                         \
 #endif /* FREEGLUT_CALLBACK_MACROS_H */
 
 /*** END OF FILE ***/
+#endif // header guard 
+

--- a/src/fg_callbacks.c
+++ b/src/fg_callbacks.c
@@ -35,7 +35,7 @@
  */
 
 /* Sets the global idle callback */
-void FGAPIENTRY glutIdleFuncUcall( FGCBIdleUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutIdleFuncUcall( FGCBIdleUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutIdleFuncUcall" );
     fgState.IdleCallback = callback;
@@ -45,7 +45,7 @@ void FGAPIENTRY glutIdleFuncUcall( FGCBIdleUC callback, FGCBUserData userData )
 IMPLEMENT_GLUT_CALLBACK_FUNC_ARG0(Idle)
 
 /* Creates a timer and sets its callback */
-void FGAPIENTRY glutTimerFuncUcall( unsigned int timeOut, FGCBTimerUC callback, int timerID, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutTimerFuncUcall( unsigned int timeOut, FGCBTimerUC callback, int timerID, FGCBUserData userData )
 {
     SFG_Timer *timer, *node;
 
@@ -79,7 +79,7 @@ void FGAPIENTRY glutTimerFuncUcall( unsigned int timeOut, FGCBTimerUC callback, 
 
 IMPLEMENT_CALLBACK_FUNC_CB_ARG1(Timer, Timer)
 
-void FGAPIENTRY glutTimerFunc( unsigned int timeOut, FGCBTimer callback, int timerID )
+FGAPI void FGAPIENTRY glutTimerFunc( unsigned int timeOut, FGCBTimer callback, int timerID )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutTimerFunc" );
     if( callback )
@@ -92,14 +92,14 @@ void FGAPIENTRY glutTimerFunc( unsigned int timeOut, FGCBTimer callback, int tim
 }
 
 /* Deprecated version of glutMenuStatusFunc callback setting method */
-void FGAPIENTRY glutMenuStateFunc( FGCBMenuState callback )
+FGAPI void FGAPIENTRY glutMenuStateFunc( FGCBMenuState callback )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutMenuStateFunc" );
     fgState.MenuStateCallback = callback;
 }
 
 /* Sets the global menu status callback for the current window */
-void FGAPIENTRY glutMenuStatusFuncUcall( FGCBMenuStatusUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutMenuStatusFuncUcall( FGCBMenuStatusUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutMenuStatusFuncUcall" );
     fgState.MenuStatusCallback = callback;
@@ -112,7 +112,7 @@ IMPLEMENT_GLUT_CALLBACK_FUNC_ARG3(MenuStatus)
  * Menu specific callbacks.
  */
 /* Callback upon menu destruction */
-void FGAPIENTRY glutMenuDestroyFuncUcall( FGCBDestroyUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutMenuDestroyFuncUcall( FGCBDestroyUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutMenuDestroyFuncUcall" );
     if( fgStructure.CurrentMenu )
@@ -154,7 +154,7 @@ IMPLEMENT_CURRENT_WINDOW_CALLBACK_FUNC_ARG1(AppStatus)
 /*
  * Sets the Display callback for the current window
  */
-void FGAPIENTRY glutDisplayFuncUcall( FGCBDisplayUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutDisplayFuncUcall( FGCBDisplayUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutDisplayFuncUcall" );
     if( !callback )
@@ -170,10 +170,10 @@ void fghDefaultReshape( int width, int height, FGCBUserData userData )
     glViewport( 0, 0, width, height );
 }
 
-void FGAPIENTRY glutReshapeFuncUcall( FGCBReshapeUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutReshapeFuncUcall( FGCBReshapeUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutReshapeFuncUcall" );
-    
+
     if( !callback )
     {
         callback = fghDefaultReshape;
@@ -216,7 +216,7 @@ static void fghVisibility( int status, FGCBUserData userData )
     INVOKE_WCB( *( fgStructure.CurrentWindow ), Visibility, ( vis_status ) );
 }
 
-void FGAPIENTRY glutVisibilityFuncUcall( FGCBVisibilityUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutVisibilityFuncUcall( FGCBVisibilityUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutVisibilityFuncUcall" );
 
@@ -238,7 +238,7 @@ IMPLEMENT_GLUT_CALLBACK_FUNC_ARG1(Visibility)
 /*
  * Sets the joystick callback and polling rate for the current window
  */
-void FGAPIENTRY glutJoystickFuncUcall( FGCBJoystickUC callback, int pollInterval, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutJoystickFuncUcall( FGCBJoystickUC callback, int pollInterval, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickFuncUcall" );
     fgInitialiseJoysticks ();
@@ -247,15 +247,15 @@ void FGAPIENTRY glutJoystickFuncUcall( FGCBJoystickUC callback, int pollInterval
            fgStructure.CurrentWindow->State.JoystickPollRate <= 0 ||        /* Joystick callback was disabled */
            !FETCH_WCB(*fgStructure.CurrentWindow,Joystick)
          ) &&
-         ( 
+         (
            callback && ( pollInterval > 0 )                                 /* but is now enabled */
          ) )
         ++fgState.NumActiveJoysticks;
-    else if ( ( 
+    else if ( (
                 fgStructure.CurrentWindow->State.JoystickPollRate > 0 &&    /* Joystick callback was enabled */
                 FETCH_WCB(*fgStructure.CurrentWindow,Joystick)
-              ) &&  
-              ( 
+              ) &&
+              (
                 !callback || ( pollInterval <= 0 )                          /* but is now disabled */
               ) )
         --fgState.NumActiveJoysticks;
@@ -277,7 +277,7 @@ static void fghJoystickFuncCallback( unsigned int buttons, int axis0, int axis1,
     (*callback)( buttons, axis0, axis1, axis2 );
 }
 
-void FGAPIENTRY glutJoystickFunc( FGCBJoystick callback, int pollInterval )
+FGAPI void FGAPIENTRY glutJoystickFunc( FGCBJoystick callback, int pollInterval )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickFunc" );
     if( callback )
@@ -292,7 +292,7 @@ void FGAPIENTRY glutJoystickFunc( FGCBJoystick callback, int pollInterval )
 /*
  * Sets the spaceball motion callback for the current window
  */
-void FGAPIENTRY glutSpaceballMotionFuncUcall( FGCBSpaceMotionUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutSpaceballMotionFuncUcall( FGCBSpaceMotionUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSpaceballMotionFuncUcall" );
     fgInitialiseSpaceball();
@@ -305,7 +305,7 @@ IMPLEMENT_GLUT_CALLBACK_FUNC_ARG3_2NAME(SpaceballMotion, SpaceMotion)
 /*
  * Sets the spaceball rotate callback for the current window
  */
-void FGAPIENTRY glutSpaceballRotateFuncUcall( FGCBSpaceRotationUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutSpaceballRotateFuncUcall( FGCBSpaceRotationUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSpaceballRotateFuncUcall" );
     fgInitialiseSpaceball();
@@ -318,7 +318,7 @@ IMPLEMENT_GLUT_CALLBACK_FUNC_ARG3_2NAME(SpaceballRotate, SpaceRotation)
 /*
  * Sets the spaceball button callback for the current window
  */
-void FGAPIENTRY glutSpaceballButtonFuncUcall( FGCBSpaceButtonUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutSpaceballButtonFuncUcall( FGCBSpaceButtonUC callback, FGCBUserData userData )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSpaceballButtonFuncUcall" );
     fgInitialiseSpaceball();

--- a/src/fg_cursor.c
+++ b/src/fg_cursor.c
@@ -56,7 +56,11 @@ void fgSetCursor ( SFG_Window *window, int cursorID )
 /*
  * Set the cursor image to be used for the current window
  */
-void FGAPIENTRY glutSetCursor( int cursorID )
+//   Added at 2024/03/25 - Pelles C compiler show error ->
+//     src\fg_cursor.c(59): error #2166: Inconsistent linkage for 'glutSetCursor', previously declared at C:\src\OpenGL\freeglut-3.4.0\include\GL\freeglut_std.h
+//   You must prefixed all function's declarations by "FGAPI" into ALL sources of Freeglut for INTERFACE FUNCTIONS of DLL on Windows.
+FGAPI void FGAPIENTRY glutSetCursor( int cursorID )
+
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetCursor" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutSetCursor" );
@@ -68,7 +72,8 @@ void FGAPIENTRY glutSetCursor( int cursorID )
 /*
  * Moves the mouse pointer to given window coordinates
  */
-void FGAPIENTRY glutWarpPointer( int x, int y )
+
+FGAPI void FGAPIENTRY glutWarpPointer( int x, int y )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWarpPointer" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutWarpPointer" );

--- a/src/fg_display.c
+++ b/src/fg_display.c
@@ -38,7 +38,7 @@ extern void fgPlatformGlutSwapBuffers( SFG_PlatformDisplay *pDisplayPtr, SFG_Win
 /*
  * Marks the current window to have the redisplay performed when possible...
  */
-void FGAPIENTRY glutPostRedisplay( void )
+FGAPI void FGAPIENTRY glutPostRedisplay( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutPostRedisplay" );
     if ( ! fgStructure.CurrentWindow )
@@ -53,7 +53,7 @@ void FGAPIENTRY glutPostRedisplay( void )
 /*
  * Swaps the buffers for the current window (if any)
  */
-void FGAPIENTRY glutSwapBuffers( void )
+FGAPI void FGAPIENTRY glutSwapBuffers( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSwapBuffers" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutSwapBuffers" );
@@ -91,7 +91,7 @@ void FGAPIENTRY glutSwapBuffers( void )
 /*
  * Mark appropriate window to be displayed
  */
-void FGAPIENTRY glutPostWindowRedisplay( int windowID )
+FGAPI void FGAPIENTRY glutPostWindowRedisplay( int windowID )
 {
     SFG_Window* window;
 

--- a/src/fg_ext.c
+++ b/src/fg_ext.c
@@ -257,7 +257,7 @@ static GLUTproc fghGetGLUTProcAddress( const char* procName )
 
 
 
-GLUTproc FGAPIENTRY
+FGAPI GLUTproc FGAPIENTRY
 glutGetProcAddress( const char *procName )
 {
     GLUTproc p;

--- a/src/fg_font.c
+++ b/src/fg_font.c
@@ -58,19 +58,20 @@ extern SFG_StrokeFont fgStrokeMonoRoman;
  */
 SFG_Font* fghFontByID( void* font )
 {
-    if( font == GLUT_BITMAP_8_BY_13        )
+
+    if( font == GLUT_BITMAP_8_BY_13)
         return &fgFontFixed8x13;
-    if( font == GLUT_BITMAP_9_BY_15        )
+    if (font == GLUT_BITMAP_9_BY_15)
         return &fgFontFixed9x15;
-    if( font == GLUT_BITMAP_HELVETICA_10   )
+    if (font == GLUT_BITMAP_HELVETICA_10)
         return &fgFontHelvetica10;
-    if( font == GLUT_BITMAP_HELVETICA_12   )
+    if (font == GLUT_BITMAP_HELVETICA_12)
         return &fgFontHelvetica12;
-    if( font == GLUT_BITMAP_HELVETICA_18   )
+    if (font == GLUT_BITMAP_HELVETICA_18)
         return &fgFontHelvetica18;
-    if( font == GLUT_BITMAP_TIMES_ROMAN_10 )
+    if (font == GLUT_BITMAP_TIMES_ROMAN_10)
         return &fgFontTimesRoman10;
-    if( font == GLUT_BITMAP_TIMES_ROMAN_24 )
+    if (font == GLUT_BITMAP_TIMES_ROMAN_24)
         return &fgFontTimesRoman24;
 
     return 0;
@@ -82,9 +83,10 @@ SFG_Font* fghFontByID( void* font )
  */
 static SFG_StrokeFont* fghStrokeByID( void* font )
 {
-    if( font == GLUT_STROKE_ROMAN      )
+
+    if (font == GLUT_STROKE_ROMAN)
         return &fgStrokeRoman;
-    if( font == GLUT_STROKE_MONO_ROMAN )
+    if (font == GLUT_STROKE_MONO_ROMAN)
         return &fgStrokeMonoRoman;
 
     return 0;
@@ -96,10 +98,13 @@ static SFG_StrokeFont* fghStrokeByID( void* font )
 /*
  * Draw a bitmap character
  */
-void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
+FGAPI void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
 {
     const GLubyte* face;
     SFG_Font* font;
+
+    int ret;
+
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutBitmapCharacter" );
     font = fghFontByID( fontID );
     if (!font)
@@ -107,11 +112,13 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
         fgWarning("glutBitmapCharacter: bitmap font 0x%08x not found. Make sure you're not passing a stroke font.\n",fontID);
         return;
     }
-    freeglut_return_if_fail( ( character >= 1 )&&( character < 256 ) );
 
-    /*
-     * Find the character we want to draw (???)
-     */
+    ret = (character >= 1) && (character < 256);
+    freeglut_return_if_fail(ret);
+
+/*
+ * Find the character we want to draw (?)
+ */
     face = font->Characters[ character ];
 
 #ifdef GL_VERSION_1_1
@@ -152,7 +159,7 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
 #endif
 }
 
-void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
+FGAPI void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
 {
     unsigned char c;
     float x = 0.0f ;
@@ -228,7 +235,7 @@ void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
 /*
  * Returns the width in pixels of a font's character
  */
-int FGAPIENTRY glutBitmapWidth( void* fontID, int character )
+FGAPI int FGAPIENTRY glutBitmapWidth( void* fontID, int character )
 {
     SFG_Font* font;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutBitmapWidth" );
@@ -245,7 +252,7 @@ int FGAPIENTRY glutBitmapWidth( void* fontID, int character )
 /*
  * Return the width of a string drawn using a bitmap font
  */
-int FGAPIENTRY glutBitmapLength( void* fontID, const unsigned char* string )
+FGAPI int FGAPIENTRY glutBitmapLength( void* fontID, const unsigned char* string )
 {
     unsigned char c;
     int length = 0, this_line_length = 0;
@@ -280,7 +287,7 @@ int FGAPIENTRY glutBitmapLength( void* fontID, const unsigned char* string )
 /*
  * Returns the height of a bitmap font
  */
-int FGAPIENTRY glutBitmapHeight( void* fontID )
+FGAPI int FGAPIENTRY glutBitmapHeight( void* fontID )
 {
     SFG_Font* font;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutBitmapHeight" );
@@ -296,7 +303,7 @@ int FGAPIENTRY glutBitmapHeight( void* fontID )
 /*
  * Draw a stroke character
  */
-void FGAPIENTRY glutStrokeCharacter( void* fontID, int character )
+FGAPI void FGAPIENTRY glutStrokeCharacter( void* fontID, int character )
 {
     const SFG_StrokeChar *schar;
     const SFG_StrokeStrip *strip;
@@ -322,7 +329,7 @@ void FGAPIENTRY glutStrokeCharacter( void* fontID, int character )
         for( j = 0; j < strip->Number; j++ )
             glVertex2f( strip->Vertices[ j ].X, strip->Vertices[ j ].Y );
         glEnd( );
-        
+
         if (fgState.StrokeFontDrawJoinDots)
         {
             glBegin( GL_POINTS );
@@ -334,7 +341,7 @@ void FGAPIENTRY glutStrokeCharacter( void* fontID, int character )
     glTranslatef( schar->Right, 0.0, 0.0 );
 }
 
-void FGAPIENTRY glutStrokeString( void* fontID, const unsigned char *string )
+FGAPI void FGAPIENTRY glutStrokeString( void* fontID, const unsigned char *string )
 {
     unsigned char c;
     int i, j;
@@ -390,7 +397,7 @@ void FGAPIENTRY glutStrokeString( void* fontID, const unsigned char *string )
 /*
  * Return the width in pixels of a stroke character
  */
-GLfloat FGAPIENTRY glutStrokeWidthf( void* fontID, int character )
+FGAPI GLfloat FGAPIENTRY glutStrokeWidthf( void* fontID, int character )
 {
     const SFG_StrokeChar *schar;
     SFG_StrokeFont* font;
@@ -410,7 +417,7 @@ GLfloat FGAPIENTRY glutStrokeWidthf( void* fontID, int character )
 
     return schar->Right;
 }
-int FGAPIENTRY glutStrokeWidth(void* fontID, int character)
+FGAPI int FGAPIENTRY glutStrokeWidth(void* fontID, int character)
 {
     return ( int )( glutStrokeWidthf(fontID,character) + 0.5f );
 }
@@ -418,7 +425,7 @@ int FGAPIENTRY glutStrokeWidth(void* fontID, int character)
 /*
  * Return the width of a string drawn using a stroke font
  */
-GLfloat FGAPIENTRY glutStrokeLengthf( void* fontID, const unsigned char* string )
+FGAPI GLfloat FGAPIENTRY glutStrokeLengthf( void* fontID, const unsigned char* string )
 {
     unsigned char c;
     GLfloat length = 0.0;
@@ -454,7 +461,7 @@ GLfloat FGAPIENTRY glutStrokeLengthf( void* fontID, const unsigned char* string 
         length = this_line_length;
     return length;
 }
-int FGAPIENTRY glutStrokeLength( void* fontID, const unsigned char* string )
+FGAPI int FGAPIENTRY glutStrokeLength( void* fontID, const unsigned char* string )
 {
     return( int )( glutStrokeLengthf(fontID,string) + 0.5f );
 }
@@ -462,7 +469,7 @@ int FGAPIENTRY glutStrokeLength( void* fontID, const unsigned char* string )
 /*
  * Returns the height of a stroke font
  */
-GLfloat FGAPIENTRY glutStrokeHeight( void* fontID )
+FGAPI GLfloat FGAPIENTRY glutStrokeHeight( void* fontID )
 {
     SFG_StrokeFont* font;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutStrokeHeight" );

--- a/src/fg_gamemode.c
+++ b/src/fg_gamemode.c
@@ -42,7 +42,7 @@ extern void fgPlatformLeaveGameMode( void );
 /*
  * Sets the game mode display string
  */
-void FGAPIENTRY glutGameModeString( const char* string )
+FGAPI void FGAPIENTRY glutGameModeString( const char* string )
 {
     int width = -1, height = -1, depth = -1, refresh = -1;
 
@@ -82,7 +82,7 @@ void FGAPIENTRY glutGameModeString( const char* string )
 /*
  * Enters the game mode
  */
-int FGAPIENTRY glutEnterGameMode( void )
+FGAPI int FGAPIENTRY glutEnterGameMode( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutEnterGameMode" );
 
@@ -113,7 +113,7 @@ int FGAPIENTRY glutEnterGameMode( void )
 /*
  * Leaves the game mode
  */
-void FGAPIENTRY glutLeaveGameMode( void )
+FGAPI void FGAPIENTRY glutLeaveGameMode( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutLeaveGameMode" );
 
@@ -130,7 +130,7 @@ void FGAPIENTRY glutLeaveGameMode( void )
 /*
  * Returns information concerning the freeglut game mode
  */
-int FGAPIENTRY glutGameModeGet( GLenum eWhat )
+FGAPI int FGAPIENTRY glutGameModeGet( GLenum eWhat )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGameModeGet" );
 

--- a/src/fg_geometry.c
+++ b/src/fg_geometry.c
@@ -1190,6 +1190,10 @@ static GLubyte tetrahedron_vi[TETRAHEDRON_VERT_PER_OBJ] =
 };
 DECLARE_SHAPE_CACHE(tetrahedron,Tetrahedron,TETRAHEDRON)
 
+/*
+ *  Added at 2024/03/23 - LCC compiler own it internally function "ipow" in include file <math.h>
+ */
+#if !defined(__LCC__)
 /* -- Sierpinski Sponge -- */
 static unsigned int ipow (int x, unsigned int y)
 {
@@ -1206,6 +1210,7 @@ static unsigned int ipow (int x, unsigned int y)
         }
     }
 }
+#endif
 
 static void fghSierpinskiSpongeGenerate ( int numLevels, double offset[3], GLfloat scale, GLfloat* vertices, GLfloat* normals )
 {
@@ -2216,7 +2221,7 @@ static void fghTorus( GLfloat dInnerRadius, GLfloat dOuterRadius, GLint nSides, 
 /*
  * Draws a solid sphere
  */
-void FGAPIENTRY glutSolidSphere(double radius, GLint slices, GLint stacks)
+FGAPI void FGAPIENTRY glutSolidSphere(double radius, GLint slices, GLint stacks)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidSphere" );
     fghSphere((GLfloat)radius, slices, stacks, GL_FALSE );
@@ -2225,7 +2230,7 @@ void FGAPIENTRY glutSolidSphere(double radius, GLint slices, GLint stacks)
 /*
  * Draws a wire sphere
  */
-void FGAPIENTRY glutWireSphere(double radius, GLint slices, GLint stacks)
+FGAPI void FGAPIENTRY glutWireSphere(double radius, GLint slices, GLint stacks)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireSphere" );
     fghSphere((GLfloat)radius, slices, stacks, GL_TRUE );
@@ -2234,7 +2239,7 @@ void FGAPIENTRY glutWireSphere(double radius, GLint slices, GLint stacks)
 /*
  * Draws a solid cone
  */
-void FGAPIENTRY glutSolidCone( double base, double height, GLint slices, GLint stacks )
+FGAPI void FGAPIENTRY glutSolidCone( double base, double height, GLint slices, GLint stacks )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidCone" );
     fghCone((GLfloat)base, (GLfloat)height, slices, stacks, GL_FALSE );
@@ -2243,7 +2248,7 @@ void FGAPIENTRY glutSolidCone( double base, double height, GLint slices, GLint s
 /*
  * Draws a wire cone
  */
-void FGAPIENTRY glutWireCone( double base, double height, GLint slices, GLint stacks)
+FGAPI void FGAPIENTRY glutWireCone( double base, double height, GLint slices, GLint stacks)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireCone" );
     fghCone((GLfloat)base, (GLfloat)height, slices, stacks, GL_TRUE );
@@ -2253,7 +2258,7 @@ void FGAPIENTRY glutWireCone( double base, double height, GLint slices, GLint st
 /*
  * Draws a solid cylinder
  */
-void FGAPIENTRY glutSolidCylinder(double radius, double height, GLint slices, GLint stacks)
+FGAPI void FGAPIENTRY glutSolidCylinder(double radius, double height, GLint slices, GLint stacks)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidCylinder" );
     fghCylinder((GLfloat)radius, (GLfloat)height, slices, stacks, GL_FALSE );
@@ -2262,7 +2267,7 @@ void FGAPIENTRY glutSolidCylinder(double radius, double height, GLint slices, GL
 /*
  * Draws a wire cylinder
  */
-void FGAPIENTRY glutWireCylinder(double radius, double height, GLint slices, GLint stacks)
+FGAPI void FGAPIENTRY glutWireCylinder(double radius, double height, GLint slices, GLint stacks)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireCylinder" );
     fghCylinder((GLfloat)radius, (GLfloat)height, slices, stacks, GL_TRUE );
@@ -2271,7 +2276,7 @@ void FGAPIENTRY glutWireCylinder(double radius, double height, GLint slices, GLi
 /*
  * Draws a wire torus
  */
-void FGAPIENTRY glutWireTorus( double dInnerRadius, double dOuterRadius, GLint nSides, GLint nRings )
+FGAPI void FGAPIENTRY glutWireTorus( double dInnerRadius, double dOuterRadius, GLint nSides, GLint nRings )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireTorus" );
     fghTorus((GLfloat)dInnerRadius, (GLfloat)dOuterRadius, nSides, nRings, GL_TRUE);
@@ -2280,7 +2285,7 @@ void FGAPIENTRY glutWireTorus( double dInnerRadius, double dOuterRadius, GLint n
 /*
  * Draws a solid torus
  */
-void FGAPIENTRY glutSolidTorus( double dInnerRadius, double dOuterRadius, GLint nSides, GLint nRings )
+FGAPI void FGAPIENTRY glutSolidTorus( double dInnerRadius, double dOuterRadius, GLint nSides, GLint nRings )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidTorus" );
     fghTorus((GLfloat)dInnerRadius, (GLfloat)dOuterRadius, nSides, nRings, GL_FALSE);
@@ -2291,23 +2296,23 @@ void FGAPIENTRY glutSolidTorus( double dInnerRadius, double dOuterRadius, GLint 
 /* -- INTERFACE FUNCTIONS -------------------------------------------------- */
 /* Macro to generate interface functions */
 #define DECLARE_SHAPE_INTERFACE(nameICaps)\
-    void FGAPIENTRY glutWire##nameICaps( void )\
+    FGAPI void FGAPIENTRY glutWire##nameICaps( void )\
     {\
         FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWire"#nameICaps );\
         fgh##nameICaps( GL_TRUE );\
     }\
-    void FGAPIENTRY glutSolid##nameICaps( void )\
+    FGAPI void FGAPIENTRY glutSolid##nameICaps( void )\
     {\
         FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolid"#nameICaps );\
         fgh##nameICaps( GL_FALSE );\
     }
 
-void FGAPIENTRY glutWireCube( double dSize )
+FGAPI void FGAPIENTRY glutWireCube( double dSize )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireCube" );
     fghCube( (GLfloat)dSize, GL_TRUE );
 }
-void FGAPIENTRY glutSolidCube( double dSize )
+FGAPI void FGAPIENTRY glutSolidCube( double dSize )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidCube" );
     fghCube( (GLfloat)dSize, GL_FALSE );
@@ -2318,12 +2323,12 @@ DECLARE_SHAPE_INTERFACE(Icosahedron)
 DECLARE_SHAPE_INTERFACE(Octahedron)
 DECLARE_SHAPE_INTERFACE(RhombicDodecahedron)
 
-void FGAPIENTRY glutWireSierpinskiSponge ( int num_levels, double offset[3], double scale )
+FGAPI void FGAPIENTRY glutWireSierpinskiSponge ( int num_levels, double offset[3], double scale )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireSierpinskiSponge" );
     fghSierpinskiSponge ( num_levels, offset, (GLfloat)scale, GL_TRUE );
 }
-void FGAPIENTRY glutSolidSierpinskiSponge ( int num_levels, double offset[3], double scale )
+FGAPI void FGAPIENTRY glutSolidSierpinskiSponge ( int num_levels, double offset[3], double scale )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidSierpinskiSponge" );
     fghSierpinskiSponge ( num_levels, offset, (GLfloat)scale, GL_FALSE );

--- a/src/fg_gl2.c
+++ b/src/fg_gl2.c
@@ -41,17 +41,17 @@ FGH_PFNGLDISABLEVERTEXATTRIBARRAYPROC fghDisableVertexAttribArray;
 FGH_PFNGLVERTEXATTRIBPOINTERPROC fghVertexAttribPointer;
 #endif
 
-void FGAPIENTRY glutSetVertexAttribCoord3(GLint attrib) {
+FGAPI void FGAPIENTRY glutSetVertexAttribCoord3(GLint attrib) {
   if (fgStructure.CurrentWindow != NULL)
     fgStructure.CurrentWindow->Window.attribute_v_coord = attrib;
 }
 
-void FGAPIENTRY glutSetVertexAttribNormal(GLint attrib) {
+FGAPI void FGAPIENTRY glutSetVertexAttribNormal(GLint attrib) {
   if (fgStructure.CurrentWindow != NULL)
     fgStructure.CurrentWindow->Window.attribute_v_normal = attrib;
 }
 
-void FGAPIENTRY glutSetVertexAttribTexCoord2(GLint attrib) {
+FGAPI void FGAPIENTRY glutSetVertexAttribTexCoord2(GLint attrib) {
     if (fgStructure.CurrentWindow != NULL)
         fgStructure.CurrentWindow->Window.attribute_v_texture = attrib;
 }

--- a/src/fg_init.c
+++ b/src/fg_init.c
@@ -75,7 +75,11 @@ SFG_State fgState = { { -1, -1, GL_FALSE },  /* Position */
                       NULL,                   /* MenuStateCallback */
                       NULL,                   /* MenuStatusCallback */
                       NULL,                   /* MenuStatusCallbackData */
+#ifdef __LCC__
+                      ((void *)0x0003),        /* LCC bug if use directly FREEGLUT_MENU_FONT : undefined reference to '_glutBitmap8By13' */
+#else
                       FREEGLUT_MENU_FONT,
+#endif
                       { -1, -1, GL_TRUE },    /* GameModeSize */
                       -1,                     /* GameModeDepth */
                       -1,                     /* GameModeRefresh */
@@ -333,7 +337,7 @@ void fgDeinitialize( void )
  * Perform initialization. This usually happens on the program startup
  * and restarting after glutMainLoop termination...
  */
-void FGAPIENTRY glutInit( int* pargc, char** argv )
+FGAPI void FGAPIENTRY glutInit( int* pargc, char** argv )
 {
     char* displayName = NULL;
     char* geometry = NULL;
@@ -391,7 +395,7 @@ void FGAPIENTRY glutInit( int* pargc, char** argv )
 /*
  * Undoes all the "glutInit" stuff
  */
-void FGAPIENTRY glutExit ( void )
+FGAPI void FGAPIENTRY glutExit ( void )
 {
   fgDeinitialize ();
 }
@@ -399,7 +403,7 @@ void FGAPIENTRY glutExit ( void )
 /*
  * Sets the default initial window position for new windows
  */
-void FGAPIENTRY glutInitWindowPosition( int x, int y )
+FGAPI void FGAPIENTRY glutInitWindowPosition( int x, int y )
 {
     fgState.Position.X = x;
     fgState.Position.Y = y;
@@ -413,7 +417,7 @@ void FGAPIENTRY glutInitWindowPosition( int x, int y )
 /*
  * Sets the default initial window size for new windows
  */
-void FGAPIENTRY glutInitWindowSize( int width, int height )
+FGAPI void FGAPIENTRY glutInitWindowSize( int width, int height )
 {
     fgState.Size.X = width;
     fgState.Size.Y = height;
@@ -427,7 +431,7 @@ void FGAPIENTRY glutInitWindowSize( int width, int height )
 /*
  * Sets the default display mode for all new windows
  */
-void FGAPIENTRY glutInitDisplayMode( unsigned int displayMode )
+FGAPI void FGAPIENTRY glutInitDisplayMode( unsigned int displayMode )
 {
     /* We will make use of this value when creating a new OpenGL context... */
     fgState.DisplayMode = displayMode;
@@ -448,7 +452,7 @@ static char* Tokens[] =
 };
 #define NUM_TOKENS             (sizeof(Tokens) / sizeof(*Tokens))
 
-void FGAPIENTRY glutInitDisplayString( const char* displayMode )
+FGAPI void FGAPIENTRY glutInitDisplayString( const char* displayMode )
 {
     int glut_state_flag = 0 ;
     /*
@@ -649,7 +653,7 @@ void FGAPIENTRY glutInitDisplayString( const char* displayMode )
 
 /* -- SETTING OPENGL 3.0 CONTEXT CREATION PARAMETERS ---------------------- */
 
-void FGAPIENTRY glutInitContextVersion( int majorVersion, int minorVersion )
+FGAPI void FGAPIENTRY glutInitContextVersion( int majorVersion, int minorVersion )
 {
     /* We will make use of these value when creating a new OpenGL context... */
     fgState.MajorVersion = majorVersion;
@@ -657,13 +661,13 @@ void FGAPIENTRY glutInitContextVersion( int majorVersion, int minorVersion )
 }
 
 
-void FGAPIENTRY glutInitContextFlags( int flags )
+FGAPI void FGAPIENTRY glutInitContextFlags( int flags )
 {
     /* We will make use of this value when creating a new OpenGL context... */
     fgState.ContextFlags = flags;
 }
 
-void FGAPIENTRY glutInitContextProfile( int profile )
+FGAPI void FGAPIENTRY glutInitContextProfile( int profile )
 {
     /* We will make use of this value when creating a new OpenGL context... */
     fgState.ContextProfile = profile;
@@ -674,7 +678,7 @@ void FGAPIENTRY glutInitContextProfile( int profile )
 /*
  * Sets the user error handler (note the use of va_list for the args to the fmt)
  */
-void FGAPIENTRY glutInitErrorFuncUcall( FGErrorUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutInitErrorFuncUcall( FGErrorUC callback, FGCBUserData userData )
 {
     /* This allows user programs to handle freeglut errors */
     fgState.ErrorFunc = callback;
@@ -687,7 +691,7 @@ static void fghInitErrorFuncCallback( const char *fmt, va_list ap, FGCBUserData 
     (*callback)( fmt, ap );
 }
 
-void FGAPIENTRY glutInitErrorFunc( FGError callback )
+FGAPI void FGAPIENTRY glutInitErrorFunc( FGError callback )
 {
     if (callback)
     {
@@ -703,7 +707,7 @@ void FGAPIENTRY glutInitErrorFunc( FGError callback )
 /*
  * Sets the user warning handler (note the use of va_list for the args to the fmt)
  */
-void FGAPIENTRY glutInitWarningFuncUcall( FGWarningUC callback, FGCBUserData userData )
+FGAPI void FGAPIENTRY glutInitWarningFuncUcall( FGWarningUC callback, FGCBUserData userData )
 {
     /* This allows user programs to handle freeglut warnings */
     fgState.WarningFunc = callback;
@@ -716,7 +720,7 @@ static void fghInitWarningFuncCallback( const char *fmt, va_list ap, FGCBUserDat
     (*callback)( fmt, ap );
 }
 
-void FGAPIENTRY glutInitWarningFunc( FGWarning callback )
+FGAPI void FGAPIENTRY glutInitWarningFunc( FGWarning callback )
 {
     if (callback)
     {

--- a/src/fg_internal.h
+++ b/src/fg_internal.h
@@ -1,3 +1,6 @@
+#ifndef HEADER_8EFE115C4BDEC61
+#define HEADER_8EFE115C4BDEC61
+
 /*
  * fg_internal.h
  *
@@ -41,7 +44,7 @@
  */
 #if !defined(TARGET_HOST_POSIX_X11) && !defined(TARGET_HOST_MS_WINDOWS) && !defined(TARGET_HOST_MAC_OSX) && !defined(TARGET_HOST_SOLARIS) && \
     !defined(TARGET_HOST_ANDROID) && !defined(TARGET_HOST_BLACKBERRY) && !defined(TARGET_HOST_POSIX_WAYLAND)
-#if defined(_MSC_VER) || defined(__WATCOMC__) || defined(__MINGW32__) \
+#if defined(_MSC_VER) || defined(__WATCOMC__) || defined(__MINGW32__) || defined(__DMC__) || defined(__BORLANDC__) \
     || defined(_WIN32) || defined(_WIN32_WCE) \
     || ( defined(__CYGWIN__) && defined(X_DISPLAY_MISSING) )
 #   define  TARGET_HOST_MS_WINDOWS 1
@@ -114,21 +117,26 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-/* These are included based on autoconf directives. */
+
+//      Modified at 2024/03/10  -  generator "nmake Makefiles" used, but in build directory, "nmake" generate an error : 				//
+//		fg_internal.h(122): fatal error C1083: Impossible d'ouvrir le fichier include : 'unistd.h' : No such file or directory (idem with Borland)  		//
+//		One solution finded : add test on unpresence of Visual C/C++ (and Borland C/C++) during generation, Not beautiful response, but it work perfectly.	//
+/* 	These are included based on autoconf directives. 		*/
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
-#ifdef HAVE_UNISTD_H
+#if defined( HAVE_UNISTD_H) && !defined(_MSC_VER) && !defined(__BORLANDC__)
 #    include <unistd.h>
 #endif
 #ifdef TIME_WITH_SYS_TIME
 #    include <sys/time.h>
 #    include <time.h>
-#elif defined(HAVE_SYS_TIME_H)
+#elif defined(HAVE_SYS_TIME_H) && !defined(_MSC_VER) && !defined(__BORLANDC__)
 #    include <sys/time.h>
 #else
 #    include <time.h>
 #endif
+
 
 /* -- AUTOCONF HACKS --------------------------------------------------------*/
 
@@ -171,11 +179,16 @@
 /* General defines */
 #define INVALID_MODIFIERS 0xffffffff
 
+//      Modified at 2024/03/10  -  generator "Borland Makefiles" used, but in build directory "make" generate an error : 	//
+//		Error E2209 C:\src\OpenGL\freeglut-3.4.0\src\fg_internal.h 125: Unable to open include file 'stdint.h' 				    	//
+//		One solution finded : add test on unpresence of Borland during generation. Not beautiful response, but it work perfectly.	//
 /* FreeGLUT internal time type */
-#if defined(HAVE_STDINT_H)
+#if defined(HAVE_STDINT_H) && !defined(__BORLANDC__)
 #   include <stdint.h>
     typedef uint64_t fg_time_t;
-#elif defined(HAVE_INTTYPES_H)
+//    Added at 2024/03/13  -  generator "Borland Makefiles" used, but in build directory "make" generate an error :	//
+//		Error E2209 C:\src\OpenGL\freeglut-3.4.0\src\fg_internal.h 125: Unable to open include file 'inttypes.h' 	//
+#elif defined(HAVE_INTTYPES_H) && !defined(__BORLANDC__)
 #   include <inttypes.h>
     typedef uint64_t fg_time_t;
 #elif defined(HAVE_U__INT64)
@@ -1176,3 +1189,5 @@ int fghNumberOfAuxBuffersRequested( void );
 #endif /* FREEGLUT_INTERNAL_H */
 
 /*** END OF FILE ***/
+#endif // header guard
+

--- a/src/fg_joystick.c
+++ b/src/fg_joystick.c
@@ -33,9 +33,13 @@
 
 #include <GL/freeglut.h>
 #include "fg_internal.h"
-#ifdef HAVE_SYS_PARAM_H
+//     Modified at 2024/03/10 - used generator "nmake Makefiles", but command "nmake" in build directory generate an arror :     //
+// 		fg_joystick.c(37): fatal error C1083: Impossible d'ouvrir le fichier include : 'sys/param.h' : No such file or directory. Idem with BCC32	//
+//		One solution finded : add test on presence of Visual Studio or Borland C during generation. Not beautiful response, but it work perfectly.  //
+#if defined(HAVE_SYS_PARAM_H) && !defined(_MSC_VER) && !defined(__BORLANDC__)
 #    include <sys/param.h>
 #endif
+
 
 #define JS_TRUE  1
 #define JS_FALSE 0
@@ -739,7 +743,7 @@ int fgJoystickDetect( void )
 /*
  * Forces the joystick callback to be executed
  */
-void FGAPIENTRY glutForceJoystickFunc( void )
+FGAPI void FGAPIENTRY glutForceJoystickFunc( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutForceJoystickFunc" );
 #if !defined(_WIN32_WCE)

--- a/src/fg_joystick.c
+++ b/src/fg_joystick.c
@@ -752,16 +752,19 @@ FGAPI void FGAPIENTRY glutForceJoystickFunc( void )
     fgJoystickPollWindow( fgStructure.CurrentWindow );
 #endif /* !defined(_WIN32_WCE) */
 }
+
 int  glutJoystickGetNumAxes( int ident )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetNumAxes" );
     return fgJoystick[ ident ]->num_axes;
 }
+
 int  glutJoystickGetNumButtons( int ident )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetNumButtons" );
     return fgJoystick[ ident ]->num_buttons;
 }
+
 int  glutJoystickNotWorking( int ident )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickNotWorking" );
@@ -773,6 +776,7 @@ float glutJoystickGetDeadBand( int ident, int axis )
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetDeadBand" );
     return fgJoystick[ ident ]->dead_band [ axis ];
 }
+
 void  glutJoystickSetDeadBand( int ident, int axis, float db )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickSetDeadBand" );
@@ -784,6 +788,7 @@ float glutJoystickGetSaturation( int ident, int axis )
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetSaturation" );
     return fgJoystick[ ident ]->saturate[ axis ];
 }
+
 void  glutJoystickSetSaturation( int ident, int axis, float st )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickSetSaturation" );
@@ -796,12 +801,14 @@ void glutJoystickSetMinRange( int ident, float *axes )
     memcpy( fgJoystick[ ident ]->min, axes,
             fgJoystick[ ident ]->num_axes * sizeof( float ) );
 }
+
 void glutJoystickSetMaxRange( int ident, float *axes )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickSetMaxRange" );
     memcpy( fgJoystick[ ident ]->max, axes,
             fgJoystick[ ident ]->num_axes * sizeof( float ) );
 }
+
 void glutJoystickSetCenter( int ident, float *axes )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickSetCenter" );
@@ -815,12 +822,14 @@ void glutJoystickGetMinRange( int ident, float *axes )
     memcpy( axes, fgJoystick[ ident ]->min,
             fgJoystick[ ident ]->num_axes * sizeof( float ) );
 }
+
 void glutJoystickGetMaxRange( int ident, float *axes )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetMaxRange" );
     memcpy( axes, fgJoystick[ ident ]->max,
             fgJoystick[ ident ]->num_axes * sizeof( float ) );
 }
+
 void glutJoystickGetCenter( int ident, float *axes )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutJoystickGetCenter" );

--- a/src/fg_main.c
+++ b/src/fg_main.c
@@ -443,7 +443,7 @@ void fgProcessWork(SFG_Window *window)
 /*
  * Executes a single iteration in the freeglut processing loop.
  */
-void FGAPIENTRY glutMainLoopEvent( void )
+FGAPI void FGAPIENTRY glutMainLoopEvent( void )
 {
     /* Process input */
     fgPlatformProcessSingleEvent ();
@@ -470,7 +470,7 @@ void FGAPIENTRY glutMainLoopEvent( void )
  * Enters the freeglut processing loop.
  * Stays until the "ExecState" changes to "GLUT_EXEC_STATE_STOP".
  */
-void FGAPIENTRY glutMainLoop( void )
+FGAPI void FGAPIENTRY glutMainLoop( void )
 {
     int action;
 
@@ -531,7 +531,7 @@ void FGAPIENTRY glutMainLoop( void )
 /*
  * Leaves the freeglut processing loop.
  */
-void FGAPIENTRY glutLeaveMainLoop( void )
+FGAPI void FGAPIENTRY glutLeaveMainLoop( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutLeaveMainLoop" );
     fgState.ExecState = GLUT_EXEC_STATE_STOP ;

--- a/src/fg_menu.c
+++ b/src/fg_menu.c
@@ -780,7 +780,7 @@ void fghCalculateMenuBoxSize( void )
 /*
  * Creates a new menu object, adding it to the freeglut structure
  */
-int FGAPIENTRY glutCreateMenuUcall( FGCBMenuUC callback, FGCBUserData userData )
+FGAPI int FGAPIENTRY glutCreateMenuUcall( FGCBMenuUC callback, FGCBUserData userData )
 {
     /* The menu object creation code resides in fg_structure.c */
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutCreateMenuUcall" );
@@ -799,7 +799,7 @@ static void fghCreateMenuCallback( int menu, FGCBUserData userData )
     (*callback)( menu );
 }
 
-int FGAPIENTRY glutCreateMenu( FGCBMenu callback )
+FGAPI int FGAPIENTRY glutCreateMenu( FGCBMenu callback )
 {
     FGCBMenu* reference;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutCreateMenu" );
@@ -814,7 +814,7 @@ int FGAPIENTRY glutCreateMenu( FGCBMenu callback )
 /*
  * Destroys a menu object, removing all references to it
  */
-void FGAPIENTRY glutDestroyMenu( int menuID )
+FGAPI void FGAPIENTRY glutDestroyMenu( int menuID )
 {
     SFG_Menu* menu;
 
@@ -832,7 +832,7 @@ void FGAPIENTRY glutDestroyMenu( int menuID )
 /*
  * Returns the ID number of the currently active menu
  */
-int FGAPIENTRY glutGetMenu( void )
+FGAPI int FGAPIENTRY glutGetMenu( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGetMenu" );
 
@@ -845,7 +845,7 @@ int FGAPIENTRY glutGetMenu( void )
 /*
  * Sets the current menu given its menu ID
  */
-void FGAPIENTRY glutSetMenu( int menuID )
+FGAPI void FGAPIENTRY glutSetMenu( int menuID )
 {
     SFG_Menu* menu;
 
@@ -860,16 +860,16 @@ void FGAPIENTRY glutSetMenu( int menuID )
 /*
  * Adds a menu entry to the bottom of the current menu
  */
-void FGAPIENTRY glutAddMenuEntry( const char* label, int value )
+FGAPI void FGAPIENTRY glutAddMenuEntry( const char* label, int value )
 {
     SFG_MenuEntry* menuEntry;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutAddMenuEntry" );
+    menuEntry = (SFG_MenuEntry *)calloc( sizeof(SFG_MenuEntry), 1 );
 
     freeglut_return_if_fail( fgStructure.CurrentMenu );
     if (fgState.ActiveMenus)
         fgError("Menu manipulation not allowed while menus in use.");
 
-    menuEntry = (SFG_MenuEntry *)calloc( sizeof(SFG_MenuEntry), 1 );
     menuEntry->Text = strdup( label );
     menuEntry->ID   = value;
 
@@ -882,12 +882,13 @@ void FGAPIENTRY glutAddMenuEntry( const char* label, int value )
 /*
  * Add a sub menu to the bottom of the current menu
  */
-void FGAPIENTRY glutAddSubMenu( const char *label, int subMenuID )
+FGAPI void FGAPIENTRY glutAddSubMenu( const char *label, int subMenuID )
 {
     SFG_MenuEntry *menuEntry;
     SFG_Menu *subMenu;
 
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutAddSubMenu" );
+    menuEntry = ( SFG_MenuEntry * )calloc( sizeof( SFG_MenuEntry ), 1 );
     subMenu = fgMenuByID( subMenuID );
 
     freeglut_return_if_fail( fgStructure.CurrentMenu );
@@ -896,7 +897,6 @@ void FGAPIENTRY glutAddSubMenu( const char *label, int subMenuID )
 
     freeglut_return_if_fail( subMenu );
 
-    menuEntry = ( SFG_MenuEntry * )calloc( sizeof( SFG_MenuEntry ), 1 );
     menuEntry->Text    = strdup( label );
     menuEntry->SubMenu = subMenu;
     menuEntry->ID      = -1;
@@ -908,7 +908,7 @@ void FGAPIENTRY glutAddSubMenu( const char *label, int subMenuID )
 /*
  * Changes the current menu's font
  */
-void FGAPIENTRY glutSetMenuFont( int menuID, void* fontID )
+FGAPI void FGAPIENTRY glutSetMenuFont( int menuID, void* fontID )
 {
     SFG_Font* font;
     SFG_Menu* menu;
@@ -933,7 +933,7 @@ void FGAPIENTRY glutSetMenuFont( int menuID, void* fontID )
 /*
  * Changes the specified menu item in the current menu into a menu entry
  */
-void FGAPIENTRY glutChangeToMenuEntry( int item, const char* label, int value )
+FGAPI void FGAPIENTRY glutChangeToMenuEntry( int item, const char* label, int value )
 {
     SFG_MenuEntry* menuEntry = NULL;
 
@@ -961,7 +961,7 @@ void FGAPIENTRY glutChangeToMenuEntry( int item, const char* label, int value )
 /*
  * Changes the specified menu item in the current menu into a sub-menu trigger.
  */
-void FGAPIENTRY glutChangeToSubMenu( int item, const char* label,
+FGAPI void FGAPIENTRY glutChangeToSubMenu( int item, const char* label,
                                      int subMenuID )
 {
     SFG_Menu*      subMenu;
@@ -996,7 +996,7 @@ void FGAPIENTRY glutChangeToSubMenu( int item, const char* label,
 /*
  * Removes the specified menu item from the current menu
  */
-void FGAPIENTRY glutRemoveMenuItem( int item )
+FGAPI void FGAPIENTRY glutRemoveMenuItem( int item )
 {
     SFG_MenuEntry* menuEntry;
 
@@ -1022,7 +1022,7 @@ void FGAPIENTRY glutRemoveMenuItem( int item )
 /*
  * Attaches a menu to the current window
  */
-void FGAPIENTRY glutAttachMenu( int button )
+FGAPI void FGAPIENTRY glutAttachMenu( int button )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutAttachMenu" );
 
@@ -1041,7 +1041,7 @@ void FGAPIENTRY glutAttachMenu( int button )
 /*
  * Detaches a menu from the current window
  */
-void FGAPIENTRY glutDetachMenu( int button )
+FGAPI void FGAPIENTRY glutDetachMenu( int button )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutDetachMenu" );
 
@@ -1060,13 +1060,13 @@ void FGAPIENTRY glutDetachMenu( int button )
 /*
  * A.Donev: Set and retrieve the menu's user data
  */
-void* FGAPIENTRY glutGetMenuData( void )
+FGAPI void* FGAPIENTRY glutGetMenuData( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGetMenuData" );
     return fgStructure.CurrentMenu->UserData;
 }
 
-void FGAPIENTRY glutSetMenuData(void* data)
+FGAPI void FGAPIENTRY glutSetMenuData(void* data)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetMenuData" );
     fgStructure.CurrentMenu->UserData=data;

--- a/src/fg_misc.c
+++ b/src/fg_misc.c
@@ -42,7 +42,7 @@ void fgPlatformCopyColormap(int win);
  *
  * XXX Wouldn't this be simpler and clearer if we used strtok()?
  */
-int FGAPIENTRY glutExtensionSupported( const char* extension )
+FGAPI int FGAPIENTRY glutExtensionSupported( const char* extension )
 {
   const char *extensions, *start;
   const size_t len = strlen( extension );
@@ -122,7 +122,7 @@ static const char* fghErrorString( GLenum error )
 /*
  * This function reports all the OpenGL errors that happened till now
  */
-void FGAPIENTRY glutReportErrors( void )
+FGAPI void FGAPIENTRY glutReportErrors( void )
 {
     GLenum error;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutReportErrors" );
@@ -133,7 +133,7 @@ void FGAPIENTRY glutReportErrors( void )
 /*
  * Control the auto-repeat of keystrokes to the current window
  */
-void FGAPIENTRY glutIgnoreKeyRepeat( int ignore )
+FGAPI void FGAPIENTRY glutIgnoreKeyRepeat( int ignore )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutIgnoreKeyRepeat" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutIgnoreKeyRepeat" );
@@ -149,7 +149,7 @@ void FGAPIENTRY glutIgnoreKeyRepeat( int ignore )
  *    GLUT_KEY_REPEAT_ON
  *    GLUT_KEY_REPEAT_DEFAULT
  */
-void FGAPIENTRY glutSetKeyRepeat( int repeatMode )
+FGAPI void FGAPIENTRY glutSetKeyRepeat( int repeatMode )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetKeyRepeat" );
 
@@ -173,7 +173,7 @@ void FGAPIENTRY glutSetKeyRepeat( int repeatMode )
 /*
  *
  */
-void FGAPIENTRY glutSetColor(int idx, GLfloat r, GLfloat g, GLfloat b)
+FGAPI void FGAPIENTRY glutSetColor(int idx, GLfloat r, GLfloat g, GLfloat b)
 {
 	FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetColor" );
 	fgPlatformSetColor(idx, r, g, b);
@@ -182,7 +182,7 @@ void FGAPIENTRY glutSetColor(int idx, GLfloat r, GLfloat g, GLfloat b)
 /*
  *
  */
-GLfloat FGAPIENTRY glutGetColor(int idx, int component)
+FGAPI GLfloat FGAPIENTRY glutGetColor(int idx, int component)
 {
 	FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGetColor" );
 	return fgPlatformGetColor(idx, component);
@@ -191,7 +191,7 @@ GLfloat FGAPIENTRY glutGetColor(int idx, int component)
 /*
  *
  */
-void FGAPIENTRY glutCopyColormap(int window)
+FGAPI void FGAPIENTRY glutCopyColormap(int window)
 {
 	FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutCopyColormap" );
 	fgPlatformCopyColormap(window);

--- a/src/fg_overlay.c
+++ b/src/fg_overlay.c
@@ -34,12 +34,12 @@
 
 /* -- INTERFACE FUNCTIONS -------------------------------------------------- */
 
-void FGAPIENTRY glutEstablishOverlay( void )             { /* Not implemented */ }
-void FGAPIENTRY glutRemoveOverlay( void )                { /* Not implemented */ }
-void FGAPIENTRY glutUseLayer( GLenum layer )             { /* Not implemented */ }
-void FGAPIENTRY glutPostOverlayRedisplay( void )         { /* Not implemented */ }
-void FGAPIENTRY glutPostWindowOverlayRedisplay( int ID ) { /* Not implemented */ }
-void FGAPIENTRY glutShowOverlay( void )                  { /* Not implemented */ }
-void FGAPIENTRY glutHideOverlay( void )                  { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutEstablishOverlay( void )             { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutRemoveOverlay( void )                { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutUseLayer( GLenum layer )             { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutPostOverlayRedisplay( void )         { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutPostWindowOverlayRedisplay( int ID ) { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutShowOverlay( void )                  { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutHideOverlay( void )                  { /* Not implemented */ }
 
 /*** END OF FILE ***/

--- a/src/fg_spaceball.c
+++ b/src/fg_spaceball.c
@@ -11,7 +11,7 @@
 #include <GL/freeglut.h>
 #include "fg_internal.h"
 
-#if( !_WIN32 || _WIN32_WINNT >= 0x0501)
+#if !defined(_WIN32) || (_WIN32_WINNT >= 0x0501)
 
 /* -- PRIVATE FUNCTIONS --------------------------------------------------- */
 

--- a/src/fg_state.c
+++ b/src/fg_state.c
@@ -57,7 +57,7 @@ extern SFG_Font* fghFontByID( void* font );
 /*
  * General settings assignment method
  */
-void FGAPIENTRY glutSetOption( GLenum eWhat, int value )
+FGAPI void FGAPIENTRY glutSetOption( GLenum eWhat, int value )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetOption" );
 
@@ -135,7 +135,7 @@ void FGAPIENTRY glutSetOption( GLenum eWhat, int value )
 /*
  * General settings query method
  */
-int FGAPIENTRY glutGet( GLenum eWhat )
+FGAPI int FGAPIENTRY glutGet( GLenum eWhat )
 {
     switch (eWhat)
     {
@@ -241,7 +241,7 @@ int FGAPIENTRY glutGet( GLenum eWhat )
 /*
  * Returns various device information.
  */
-int FGAPIENTRY glutDeviceGet( GLenum eWhat )
+FGAPI int FGAPIENTRY glutDeviceGet( GLenum eWhat )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutDeviceGet" );
 
@@ -300,7 +300,7 @@ int FGAPIENTRY glutDeviceGet( GLenum eWhat )
 /*
  * This should return the current state of ALT, SHIFT and CTRL keys.
  */
-int FGAPIENTRY glutGetModifiers( void )
+FGAPI int FGAPIENTRY glutGetModifiers( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGetModifiers" );
     if( fgState.Modifiers == INVALID_MODIFIERS )
@@ -315,7 +315,7 @@ int FGAPIENTRY glutGetModifiers( void )
 /*
  * Return the state of the GLUT API overlay subsystem. A misery ;-)
  */
-int FGAPIENTRY glutLayerGet( GLenum eWhat )
+FGAPI int FGAPIENTRY glutLayerGet( GLenum eWhat )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutLayerGet" );
 
@@ -361,7 +361,7 @@ int FGAPIENTRY glutLayerGet( GLenum eWhat )
     return -1;
 }
 
-int * FGAPIENTRY glutGetModeValues(GLenum eWhat, int *size)
+FGAPI int * FGAPIENTRY glutGetModeValues(GLenum eWhat, int *size)
 {
   int *array;
 

--- a/src/fg_teapot.c
+++ b/src/fg_teapot.c
@@ -478,7 +478,7 @@ static void fghTeaset( GLfloat scale, GLboolean useWireMode,
 /*
  * Renders a wired teapot...
  */
-void FGAPIENTRY glutWireTeapot( double size )
+FGAPI void FGAPIENTRY glutWireTeapot( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireTeapot" );
     fghTeaset( (GLfloat)size, GL_TRUE,
@@ -493,7 +493,7 @@ void FGAPIENTRY glutWireTeapot( double size )
 /*
  * Renders a filled teapot...
  */
-void FGAPIENTRY glutSolidTeapot( double size )
+FGAPI void FGAPIENTRY glutSolidTeapot( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidTeapot" );
     fghTeaset( (GLfloat)size, GL_FALSE,
@@ -509,7 +509,7 @@ void FGAPIENTRY glutSolidTeapot( double size )
 /*
  * Renders a wired teacup...
  */
-void FGAPIENTRY glutWireTeacup( double size )
+FGAPI void FGAPIENTRY glutWireTeacup( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireTeacup" );
     fghTeaset( (GLfloat)size/2.5f, GL_TRUE,
@@ -524,7 +524,7 @@ void FGAPIENTRY glutWireTeacup( double size )
 /*
  * Renders a filled teacup...
  */
-void FGAPIENTRY glutSolidTeacup( double size )
+FGAPI void FGAPIENTRY glutSolidTeacup( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidTeacup" );
     fghTeaset( (GLfloat)size/2.5f, GL_FALSE,
@@ -540,7 +540,7 @@ void FGAPIENTRY glutSolidTeacup( double size )
 /*
  * Renders a wired teaspoon...
  */
-void FGAPIENTRY glutWireTeaspoon( double size )
+FGAPI void FGAPIENTRY glutWireTeaspoon( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutWireTeaspoon" );
     fghTeaset( (GLfloat)size/2.5f, GL_TRUE,
@@ -555,7 +555,7 @@ void FGAPIENTRY glutWireTeaspoon( double size )
 /*
  * Renders a filled teaspoon...
  */
-void FGAPIENTRY glutSolidTeaspoon( double size )
+FGAPI void FGAPIENTRY glutSolidTeaspoon( double size )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSolidTeaspoon" );
     fghTeaset( (GLfloat)size/2.5f, GL_FALSE,

--- a/src/fg_videoresize.c
+++ b/src/fg_videoresize.c
@@ -34,11 +34,11 @@
 
 /* -- INTERFACE FUNCTIONS -------------------------------------------------- */
 
-int  FGAPIENTRY glutVideoResizeGet( GLenum eWhat )            {    return( 0x00 );    }
-void FGAPIENTRY glutSetupVideoResizing( void )                { /* Not implemented */ }
-void FGAPIENTRY glutStopVideoResizing( void )                 { /* Not implemented */ }
-void FGAPIENTRY glutVideoResize( int x, int y, int w, int h ) { /* Not implemented */ }
-void FGAPIENTRY glutVideoPan( int x, int y, int w, int h )    { /* Not implemented */ }
+FGAPI int  FGAPIENTRY glutVideoResizeGet( GLenum eWhat )            {    return( 0x00 );    }
+FGAPI void FGAPIENTRY glutSetupVideoResizing( void )                { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutStopVideoResizing( void )                 { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutVideoResize( int x, int y, int w, int h ) { /* Not implemented */ }
+FGAPI void FGAPIENTRY glutVideoPan( int x, int y, int w, int h )    { /* Not implemented */ }
 
 /*** END OF FILE ***/
 

--- a/src/fg_window.c
+++ b/src/fg_window.c
@@ -177,7 +177,7 @@ void fgCloseWindow( SFG_Window* window )
 /*
  * Creates a new top-level freeglut window
  */
-int FGAPIENTRY glutCreateWindow( const char* title )
+FGAPI int FGAPIENTRY glutCreateWindow( const char* title )
 {
     /* XXX GLUT does not exit; it simply calls "glutInit" quietly if the
      * XXX application has not already done so.  The "freeglut" community
@@ -187,7 +187,7 @@ int FGAPIENTRY glutCreateWindow( const char* title )
      */
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutCreateWindow" );
 
-    return fgCreateWindow( NULL, title, 
+    return fgCreateWindow( NULL, title,
                            fgState.Position.Use, fgState.Position.X, fgState.Position.Y,
                            fgState.Size.Use, fgState.Size.X, fgState.Size.Y,
                            GL_FALSE, GL_FALSE )->ID;
@@ -196,7 +196,7 @@ int FGAPIENTRY glutCreateWindow( const char* title )
 /*
  * This function creates a sub window.
  */
-int FGAPIENTRY glutCreateSubWindow( int parentID, int x, int y, int w, int h )
+FGAPI int FGAPIENTRY glutCreateSubWindow( int parentID, int x, int y, int w, int h )
 {
     int ret = 0;
     SFG_Window* window = NULL;
@@ -246,9 +246,9 @@ int FGAPIENTRY glutCreateSubWindow( int parentID, int x, int y, int w, int h )
         }
     }
 
-    window = fgCreateWindow( parent, "", 
-                             GL_TRUE, x, y, 
-                             GL_TRUE, w, h, 
+    window = fgCreateWindow( parent, "",
+                             GL_TRUE, x, y,
+                             GL_TRUE, w, h,
                              GL_FALSE, GL_FALSE );
     ret = window->ID;
 
@@ -258,7 +258,7 @@ int FGAPIENTRY glutCreateSubWindow( int parentID, int x, int y, int w, int h )
 /*
  * Destroys a window and all of its subwindows
  */
-void FGAPIENTRY glutDestroyWindow( int windowID )
+FGAPI void FGAPIENTRY glutDestroyWindow( int windowID )
 {
     SFG_Window* window;
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutDestroyWindow" );
@@ -274,7 +274,7 @@ void FGAPIENTRY glutDestroyWindow( int windowID )
 /*
  * This function selects the specified window as the current window
  */
-void FGAPIENTRY glutSetWindow( int ID )
+FGAPI void FGAPIENTRY glutSetWindow( int ID )
 {
     SFG_Window* window = NULL;
 
@@ -296,7 +296,7 @@ void FGAPIENTRY glutSetWindow( int ID )
 /*
  * This function returns the ID number of the current window, 0 if none exists
  */
-int FGAPIENTRY glutGetWindow( void )
+FGAPI int FGAPIENTRY glutGetWindow( void )
 {
     SFG_Window *win = fgStructure.CurrentWindow;
     /*
@@ -315,7 +315,7 @@ int FGAPIENTRY glutGetWindow( void )
 /*
  * This function makes the current window visible
  */
-void FGAPIENTRY glutShowWindow( void )
+FGAPI void FGAPIENTRY glutShowWindow( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutShowWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutShowWindow" );
@@ -329,7 +329,7 @@ void FGAPIENTRY glutShowWindow( void )
 /*
  * This function hides the current window
  */
-void FGAPIENTRY glutHideWindow( void )
+FGAPI void FGAPIENTRY glutHideWindow( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutHideWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutHideWindow" );
@@ -343,7 +343,7 @@ void FGAPIENTRY glutHideWindow( void )
 /*
  * Iconify the current window (top-level windows only)
  */
-void FGAPIENTRY glutIconifyWindow( void )
+FGAPI void FGAPIENTRY glutIconifyWindow( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutIconifyWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutIconifyWindow" );
@@ -357,7 +357,7 @@ void FGAPIENTRY glutIconifyWindow( void )
 /*
  * Set the current window's title
  */
-void FGAPIENTRY glutSetWindowTitle( const char* title )
+FGAPI void FGAPIENTRY glutSetWindowTitle( const char* title )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetWindowTitle" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutSetWindowTitle" );
@@ -370,7 +370,7 @@ void FGAPIENTRY glutSetWindowTitle( const char* title )
 /*
  * Set the current window's iconified title
  */
-void FGAPIENTRY glutSetIconTitle( const char* title )
+FGAPI void FGAPIENTRY glutSetIconTitle( const char* title )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetIconTitle" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutSetIconTitle" );
@@ -384,7 +384,7 @@ void FGAPIENTRY glutSetIconTitle( const char* title )
 /*
  * Change the current window's size
  */
-void FGAPIENTRY glutReshapeWindow( int width, int height )
+FGAPI void FGAPIENTRY glutReshapeWindow( int width, int height )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutReshapeWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutReshapeWindow" );
@@ -403,7 +403,7 @@ void FGAPIENTRY glutReshapeWindow( int width, int height )
 /*
  * Change the current window's position
  */
-void FGAPIENTRY glutPositionWindow( int x, int y )
+FGAPI void FGAPIENTRY glutPositionWindow( int x, int y )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutPositionWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutPositionWindow" );
@@ -422,7 +422,7 @@ void FGAPIENTRY glutPositionWindow( int x, int y )
 /*
  * Lowers the current window (by Z order change)
  */
-void FGAPIENTRY glutPushWindow( void )
+FGAPI void FGAPIENTRY glutPushWindow( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutPushWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutPushWindow" );
@@ -434,7 +434,7 @@ void FGAPIENTRY glutPushWindow( void )
 /*
  * Raises the current window (by Z order change)
  */
-void FGAPIENTRY glutPopWindow( void )
+FGAPI void FGAPIENTRY glutPopWindow( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutPopWindow" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutPopWindow" );
@@ -446,7 +446,7 @@ void FGAPIENTRY glutPopWindow( void )
 /*
  * Resize the current window so that it fits the whole screen
  */
-void FGAPIENTRY glutFullScreen( void )
+FGAPI void FGAPIENTRY glutFullScreen( void )
 {
     SFG_Window *win;
 
@@ -479,7 +479,7 @@ void FGAPIENTRY glutFullScreen( void )
 /*
  * If we are fullscreen, resize the current window back to its original size
  */
-void FGAPIENTRY glutLeaveFullScreen( void )
+FGAPI void FGAPIENTRY glutLeaveFullScreen( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutFullScreen" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutFullScreen" );
@@ -491,7 +491,7 @@ void FGAPIENTRY glutLeaveFullScreen( void )
 /*
  * Toggle the window's full screen state.
  */
-void FGAPIENTRY glutFullScreenToggle( void )
+FGAPI void FGAPIENTRY glutFullScreenToggle( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutFullScreenToggle" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutFullScreenToggle" );
@@ -502,14 +502,14 @@ void FGAPIENTRY glutFullScreenToggle( void )
 /*
  * A.Donev: Set and retrieve the window's user data
  */
-void* FGAPIENTRY glutGetWindowData( void )
+FGAPI void* FGAPIENTRY glutGetWindowData( void )
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutGetWindowData" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutGetWindowData" );
     return fgStructure.CurrentWindow->UserData;
 }
 
-void FGAPIENTRY glutSetWindowData(void* data)
+FGAPI void FGAPIENTRY glutSetWindowData(void* data)
 {
     FREEGLUT_EXIT_IF_NOT_INITIALISED ( "glutSetWindowData" );
     FREEGLUT_EXIT_IF_NO_WINDOW ( "glutSetWindowData" );

--- a/src/mswin/fg_cursor_mswin.c
+++ b/src/mswin/fg_cursor_mswin.c
@@ -27,7 +27,11 @@
 
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
-
+#if __CYGWIN__
+#define _WIN32
+#include <windows.h>
+#include <winuser.h>
+#endif
 
 
 void fgPlatformSetCursor ( SFG_Window *window, int cursorID )

--- a/src/mswin/fg_init_mswin.c
+++ b/src/mswin/fg_init_mswin.c
@@ -47,7 +47,7 @@ void fgPlatformInitialize( const char* displayName )
 
     /* What we need to do is to initialize the fgDisplay global structure here. */
     fgDisplay.pDisplay.Instance = GetModuleHandle( NULL );
-    fgDisplay.pDisplay.DisplayName= displayName ? fghTstrFromStr(displayName) : 0 ;
+    fgDisplay.pDisplay.DisplayName= displayName ? strdup(displayName) : 0 ;
     atom = GetClassInfo( fgDisplay.pDisplay.Instance, _T("FREEGLUT"), &wc );
 
     if( atom == 0 )
@@ -169,8 +169,9 @@ void fgPlatformDestroyContext ( SFG_PlatformDisplay pDisplay, SFG_WindowContextT
 
 void (__cdecl *__glutExitFunc)( int return_value ) = NULL;
 
-void FGAPIENTRY __glutInitWithExit( int *pargc, char **argv, void (__cdecl *exit_function)(int) )
+FGAPI void FGAPIENTRY __glutInitWithExit( int *pargc, char **argv, void (__cdecl *exit_function)(int) )
 {
   __glutExitFunc = exit_function;
   glutInit(pargc, argv);
 }
+

--- a/src/mswin/fg_input_devices_mswin.c
+++ b/src/mswin/fg_input_devices_mswin.c
@@ -29,7 +29,14 @@
 #include "../fg_internal.h"
 
 #include <sys/types.h>
+/*
+ *   Added at 2024/03/23 - LCC compiler don't use "winbase.h", all is present in one file "win.h" loaded by "windows.h".
+ */
+#ifdef __LCC__
+#include <windows.h>
+#else
 #include <winbase.h>
+#endif // __LCC__
 
 struct _serialport {
    HANDLE fh;
@@ -71,10 +78,8 @@ SERIALPORT *fg_serial_open(const char *device){
     COMMTIMEOUTS timeouts;
     SERIALPORT *port;
 
-    TCHAR* tdevice = fghTstrFromStr(device);
-    fh = CreateFile(tdevice,GENERIC_READ|GENERIC_WRITE,0,NULL,
+    fh = CreateFile(device,GENERIC_READ|GENERIC_WRITE,0,NULL,
       OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,NULL);
-    free(tdevice);
     if (!fh) return NULL;
 
     port = malloc(sizeof(SERIALPORT));
@@ -86,7 +91,7 @@ SERIALPORT *fg_serial_open(const char *device){
     GetCommTimeouts(fh,&port->timeouts_save);
 
     dcb.DCBlength=sizeof(DCB);
-    BuildCommDCBA("96,n,8,1",&dcb);
+    BuildCommDCB("96,n,8,1",&dcb);
     SetCommState(fh,&dcb);
 
     ZeroMemory(&timeouts,sizeof(timeouts));
@@ -128,3 +133,4 @@ void fg_serial_flush ( SERIALPORT *port )
 {
     FlushFileBuffers(port->fh);
 }
+

--- a/src/mswin/fg_internal_mswin.h
+++ b/src/mswin/fg_internal_mswin.h
@@ -1,3 +1,6 @@
+#ifndef HEADER_16924EAD7B7F2FF
+#define HEADER_16924EAD7B7F2FF
+
 /*
  * fg_internal_mswin.h
  *
@@ -67,7 +70,7 @@ struct tagSFG_PlatformDisplay
 {
     HINSTANCE       Instance;           /* The application's instance */
     DEVMODE         DisplayMode;        /* Desktop's display settings */
-    TCHAR          *DisplayName;        /* Display name for multi display support*/
+    char           *DisplayName;        /* Display name for multi display support*/
 };
 
 /*
@@ -101,8 +104,8 @@ struct tagSFG_PlatformWindowState
      * one title associated with a window and we need to swap
      * them out based on the window's iconic state
      */
-    TCHAR*          WindowTitle;
-    TCHAR*          IconTitle;
+    char*           WindowTitle;
+    char*           IconTitle;
 };
 
 
@@ -121,7 +124,8 @@ struct tagSFG_PlatformJoystick
 
 
 /* Menu font and color definitions */
-#define  FREEGLUT_MENU_FONT    GLUT_BITMAP_8_BY_13
+
+#define  FREEGLUT_MENU_FONT     GLUT_BITMAP_8_BY_13
 
 #define  FREEGLUT_MENU_PEN_FORE_COLORS   {0.0f,  0.0f,  0.0f,  1.0f}
 #define  FREEGLUT_MENU_PEN_BACK_COLORS   {0.85f, 0.85f, 0.85f, 1.0f}
@@ -138,7 +142,7 @@ void fgSpaceballHandleWinEvent(HWND hwnd, WPARAM wParam, LPARAM lParam);
 /* Function to be called on exit */
 extern void (__cdecl *__glutExitFunc)( int return_value );
 
-// Defined in fg_window_mswin.c
-TCHAR* fghTstrFromStr(const char* str);
 
 #endif  /* FREEGLUT_INTERNAL_MSWIN_H */
+#endif // header guard
+

--- a/src/mswin/fg_joystick_mswin.c
+++ b/src/mswin/fg_joystick_mswin.c
@@ -117,11 +117,9 @@ void fgPlatformJoystickRawRead( SFG_Joystick* joy, int* buttons, float* axes )
 
 static int fghJoystickGetOEMProductName ( SFG_Joystick* joy, char *buf, int buf_sz )
 {
-    TCHAR buffer [ 256 ];
-    const size_t bufferSize = sizeof buffer / sizeof buffer[0];
+    char buffer [ 256 ];
 
-    TCHAR OEMKey [ 256 ];
-    const size_t OEMKeySize = sizeof OEMKey / sizeof OEMKey[0];
+    char OEMKey [ 256 ];
 
     HKEY  hKey;
     DWORD dwcb;
@@ -131,19 +129,19 @@ static int fghJoystickGetOEMProductName ( SFG_Joystick* joy, char *buf, int buf_
         return 0;
 
     /* Open .. MediaResources\CurrentJoystickSettings */
-    _sntprintf ( buffer, bufferSize, _T("%s\\%s\\%s"),
-                 REGSTR_PATH_JOYCONFIG, joy->pJoystick.jsCaps.szRegKey,
-                 REGSTR_KEY_JOYCURR );
+    _snprintf ( buffer, sizeof(buffer), "%s\\%s\\%s",
+                REGSTR_PATH_JOYCONFIG, joy->pJoystick.jsCaps.szRegKey,
+                REGSTR_KEY_JOYCURR );
 
     lr = RegOpenKeyEx ( HKEY_LOCAL_MACHINE, buffer, 0, KEY_QUERY_VALUE, &hKey);
 
     if ( lr != ERROR_SUCCESS ) return 0;
 
     /* Get OEM Key name */
-    dwcb = OEMKeySize;
+    dwcb = sizeof(OEMKey);
 
     /* JOYSTICKID1-16 is zero-based; registry entries for VJOYD are 1-based. */
-    _sntprintf ( buffer, bufferSize, _T("Joystick%d%s"), joy->pJoystick.js_id + 1, REGSTR_VAL_JOYOEMNAME );
+    _snprintf ( buffer, sizeof(buffer), "Joystick%d%s", joy->pJoystick.js_id + 1, REGSTR_VAL_JOYOEMNAME );
 
     lr = RegQueryValueEx ( hKey, buffer, 0, 0, (LPBYTE) OEMKey, &dwcb);
     RegCloseKey ( hKey );
@@ -151,7 +149,7 @@ static int fghJoystickGetOEMProductName ( SFG_Joystick* joy, char *buf, int buf_
     if ( lr != ERROR_SUCCESS ) return 0;
 
     /* Open OEM Key from ...MediaProperties */
-    _sntprintf ( buffer, bufferSize, _T("%s\\%s"), REGSTR_PATH_JOYOEM, OEMKey );
+    _snprintf ( buffer, sizeof(buffer), "%s\\%s", REGSTR_PATH_JOYOEM, OEMKey );
 
     lr = RegOpenKeyEx ( HKEY_LOCAL_MACHINE, buffer, 0, KEY_QUERY_VALUE, &hKey );
 
@@ -197,12 +195,7 @@ void fgPlatformJoystickOpen( SFG_Joystick* joy )
                                              sizeof( joy->name ) ) )
         {
             fgWarning( "JS: Failed to read joystick name from registry" );
-#ifdef UNICODE
-            WideCharToMultiByte(CP_UTF8, 0, joy->pJoystick.jsCaps.szPname, MAXPNAMELEN,
-                                joy->name, sizeof( joy->name ), NULL, NULL);
-#else
             strncpy( joy->name, joy->pJoystick.jsCaps.szPname, sizeof( joy->name ) );
-#endif
         }
 
         /* Windows joystick drivers may provide any combination of
@@ -268,3 +261,4 @@ void fgPlatformJoystickClose ( int ident )
     /* Do nothing special */
 }
 #endif
+

--- a/src/mswin/fg_main_mswin.c
+++ b/src/mswin/fg_main_mswin.c
@@ -27,6 +27,11 @@
 
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
+#include "fg_internal_mswin.h"
+//      Modified at 2024/03/19  -  error using Digital Mars Compiler, because "initial" winuser.h is insuffisant
+//      I must added definitions and functions used by Freeglut directly in this include file.
+//      And force #include in this file. Don't test __DMC__ here, because "winuser.h" is present with all compilers.
+#include <winuser.h>
 
 extern void fghRedrawWindow ( SFG_Window *window );
 extern void fghRedrawWindowAndChildren ( SFG_Window *window );
@@ -44,8 +49,8 @@ extern void fgPlatformCheckMenuDeactivate(HWND newFocusWnd);
 #ifdef WM_TOUCH
 typedef BOOL (WINAPI *pGetTouchInputInfo)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
 typedef BOOL (WINAPI *pCloseTouchInputHandle)(HTOUCHINPUT);
-static pGetTouchInputInfo fghGetTouchInputInfo = (pGetTouchInputInfo)((size_t)0xDEADBEEF);
-static pCloseTouchInputHandle fghCloseTouchInputHandle = (pCloseTouchInputHandle)((size_t)0xDEADBEEF);
+static pGetTouchInputInfo fghGetTouchInputInfo = (pGetTouchInputInfo)0xDEADBEEF;
+static pCloseTouchInputHandle fghCloseTouchInputHandle = (pCloseTouchInputHandle)0xDEADBEEF;
 #endif
 
 #ifdef _WIN32_WCE
@@ -1487,7 +1492,7 @@ LRESULT CALLBACK fgPlatformWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 #endif /* WINVER >= 0x0400 */
 
             default:
-#if _DEBUG
+#if defined(_DEBUG)
                 fgWarning( "Unknown wParam type 0x%x", wParam );
 #endif
                 break;
@@ -1507,9 +1512,9 @@ LRESULT CALLBACK fgPlatformWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
         unsigned int i = 0;
         TOUCHINPUT* ti = (TOUCHINPUT*)malloc( sizeof(TOUCHINPUT)*numInputs);
 
-        if (fghGetTouchInputInfo == (pGetTouchInputInfo)((size_t)0xDEADBEEF)) {
-            fghGetTouchInputInfo = (pGetTouchInputInfo)GetProcAddress(GetModuleHandleA("user32"),"GetTouchInputInfo");
-            fghCloseTouchInputHandle = (pCloseTouchInputHandle)GetProcAddress(GetModuleHandleA("user32"),"CloseTouchInputHandle");
+        if (fghGetTouchInputInfo == (pGetTouchInputInfo)0xDEADBEEF) {
+            fghGetTouchInputInfo = (pGetTouchInputInfo)GetProcAddress(GetModuleHandle("user32"),"GetTouchInputInfo");
+            fghCloseTouchInputHandle = (pCloseTouchInputHandle)GetProcAddress(GetModuleHandle("user32"),"CloseTouchInputHandle");
         }
 
         if (!fghGetTouchInputInfo) {

--- a/src/mswin/fg_menu_mswin.c
+++ b/src/mswin/fg_menu_mswin.c
@@ -100,13 +100,13 @@ void fgPlatformCheckMenuDeactivate(HWND newFocusWnd)
 
 /* -- PLATFORM-SPECIFIC INTERFACE FUNCTION -------------------------------------------------- */
 
-int FGAPIENTRY __glutCreateMenuWithExit( void(* callback)( int ), void (__cdecl *exit_function)(int) )
+FGAPI int FGAPIENTRY __glutCreateMenuWithExit( void(* callback)( int ), void (__cdecl *exit_function)(int) )
 {
   __glutExitFunc = exit_function;
   return glutCreateMenu( callback );
 }
 
-int FGAPIENTRY __glutCreateMenuUcallWithExit(void(*callback)(int, void*), void(__cdecl *exit_function)(int), void* user_data)
+FGAPI int FGAPIENTRY __glutCreateMenuUcallWithExit(void(*callback)(int, void*), void(__cdecl *exit_function)(int), void* user_data)
 {
     __glutExitFunc = exit_function;
     return glutCreateMenuUcall(callback, user_data);

--- a/src/mswin/fg_spaceball_mswin.c
+++ b/src/mswin/fg_spaceball_mswin.c
@@ -40,6 +40,11 @@
 
 #include <GL/freeglut.h>
 #include <stdlib.h>
+//       Added at 2024/03/14 - Borland C, force include of winuser.h.
+//  	Not suffisant : add many definition of structure, variables and functions in include file winuser.h of BC55, to satisfy compilation.
+#if defined(__BORLANDC__)
+#include <winuser.h>
+#endif
 #include "../fg_internal.h"
 
 enum {
@@ -51,25 +56,26 @@ enum {
 
 extern int fg_sball_initialized;
 unsigned int __fgSpaceKeystate = 0;
+//       Added at 2024/03/14 - Borland C is not compatible with C99, initialisation of structure don't be realize with {.....}
+#if defined(__BORLANDC__)
+RAWINPUTDEVICE __fgSpaceball ;
+#else
 RAWINPUTDEVICE __fgSpaceball = { 0x01, 0x08, 0x00, 0x00 };
-
-/* It seems like some versions of winuser.h define RAWHID.bRawData as an array
- * (which makes sense because that's where the data start), and some define it
- * as a single byte, which is insane. This is probably a mistake which got
- * distributed by accident, but it means we need to work around it by defining
- * our own RAWHID structure.
- */
-struct fgRAWHID {
-    DWORD dwSizeHid;
-    DWORD dwCount;
-    BYTE bRawData[1];
-};
-
+#endif
 
 void fgPlatformInitializeSpaceball(void)
 {
     HWND hwnd;
     fg_sball_initialized = 1;
+//       Added at 2024/03/14 - Borland C is not compatible with C99, initialisation of structure don't be realize with {.....}
+//       but with explicit affectation field by field ...   GRRRR !!!
+#if defined(__BORLANDC__)
+	__fgSpaceball.usUsagePage = 0x01 ;
+	__fgSpaceball.usUsage = 0x08 ;
+    __fgSpaceball.dwFlags = 0x00 ;
+    __fgSpaceball.hwndTarget =  0x00 ;
+#endif
+
     if (!fgStructure.CurrentWindow)
     {
         fg_sball_initialized = 0;
@@ -119,6 +125,7 @@ void fgSpaceballHandleWinEvent(HWND hwnd, WPARAM wParam, LPARAM lParam)
 {
     #define LOGITECH_VENDOR_ID 0x46d
     HRAWINPUT hRawInput = (HRAWINPUT)lParam;
+    UINT inputCode = (UINT)wParam;
     UINT size;
     BYTE *rawInputBuffer;
     PRAWINPUT pRawInput;
@@ -159,35 +166,34 @@ void fgSpaceballHandleWinEvent(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
         if (sRidDeviceInfo.hid.dwVendorId == LOGITECH_VENDOR_ID)
         {
-            /* see definition of fgRAWHID at the top of this file, for an
-             * explanation of why we're doing this.
-             */
-            struct fgRAWHID *hid = (struct fgRAWHID*)&pRawInput->data.hid;
-
-            /* Motion data comes in two parts: motion type and */
-            /* displacement/rotation along three axis. */
-            /* Orientation is a right handed coordinate system with */
-            /* X goes right, Y goes up and Z goes towards viewer, e.g. */
-            /* the one used in OpenGL */
-            if (hid->bRawData[0] == SPNAV_EVENT_MOTION_TRANSLATION)
-            { /* Translation vector */
-                short* pnData = (short*)(&hid->bRawData[1]);
+            // Motion data comes in two parts: motion type and
+            // displacement/rotation along three axis.
+            // Orientation is a right handed coordinate system with
+            // X goes right, Y goes up and Z goes towards viewer, e.g.
+            // the one used in OpenGL
+            if (pRawInput->data.hid.bRawData[0] ==
+                SPNAV_EVENT_MOTION_TRANSLATION)
+            { // Translation vector
+                short* pnData = (short*)(&pRawInput->data.hid.bRawData[1]);
                 short X = pnData[0];
                 short Y = -pnData[2];
                 short Z = pnData[1];
                 INVOKE_WCB(*window, SpaceMotion, (X, Y, Z));
             }
-            else if (hid->bRawData[0] == SPNAV_EVENT_MOTION_ROTATION)
-            { /* Axis aligned rotation vector */
-                short* pnData = (short*)(&hid->bRawData[1]);
+            else if (pRawInput->data.hid.bRawData[0] ==
+                SPNAV_EVENT_MOTION_ROTATION)
+            { // Axis aligned rotation vector
+                short* pnData = (short*)(&pRawInput->data.hid.bRawData[1]);
                 short rX = pnData[0];
                 short rY = -pnData[2];
                 short rZ = pnData[1];
                 INVOKE_WCB(*window, SpaceRotation, (rX, rY, rZ));
             }
-            else if (hid->bRawData[0] == SPNAV_EVENT_BUTTON)
-            { /* State of the keys */
-                unsigned long dwKeystate = *(unsigned long*)(&hid->bRawData[1]);
+            else if (pRawInput->data.hid.bRawData[0] ==
+                SPNAV_EVENT_BUTTON)
+            { // State of the keys
+                unsigned long dwKeystate = *(unsigned long*)(&pRawInput->data.hid.bRawData[1]);
+                unsigned int state = GLUT_UP;
                 if (FETCH_WCB(*window, SpaceButton))
                 {
                     int i;

--- a/src/mswin/fg_window_mswin.c
+++ b/src/mswin/fg_window_mswin.c
@@ -876,7 +876,7 @@ void fgPlatformGlutSetIconTitle( const char* title )
 
 /* -- PLATFORM-SPECIFIC INTERFACE FUNCTION -------------------------------------------------- */
 
-int FGAPIENTRY __glutCreateWindowWithExit( const char *title, void (__cdecl *exit_function)(int) )
+FGAPI int FGAPIENTRY __glutCreateWindowWithExit( const char *title, void (__cdecl *exit_function)(int) )
 {
   __glutExitFunc = exit_function;
   return glutCreateWindow( title );


### PR DESCRIPTION
In addition of my tests of build Freeglut v3.4.0 on Windows, I constat that Pelles C Compiler is most very strict than all others compilers tested (CLANG,MINGW, MSVC, DMC, Borland C, etc...). It impose that all core instanciation of Interface functions of FG be preceed by FGAPI like declaration in "include\GL\freeglut_std.h".
For all others compilers tested this evolution is totally transparent, I realize this operation on all sources concerned of FG.
Thank's.
Thierry D.  
