### PR TITLE
Let platforms override the maximum number of joysticks

### DIFF
--- a/src/fg_internal.h
+++ b/src/fg_internal.h
@@ -912,6 +912,11 @@ struct tagSFG_StrokeFont
  */
 #define _JS_MAX_BUTTONS 32
 
+/* Platforms can override this in their internal include file */
+#ifndef MAX_NUM_JOYSTICKS
+#define MAX_NUM_JOYSTICKS 2
+#endif
+
 #if TARGET_HOST_MACINTOSH
 #    define _JS_MAX_AXES  9
 typedef struct tagSFG_PlatformJoystick SFG_PlatformJoystick;

--- a/src/fg_joystick.c
+++ b/src/fg_joystick.c
@@ -70,7 +70,6 @@ extern void fgPlatformJoystickClose ( int ident );
 /*
  * The static joystick structure pointer
  */
-#define MAX_NUM_JOYSTICKS  2
 SFG_Joystick *fgJoystick [ MAX_NUM_JOYSTICKS ];
 
 /*


### PR DESCRIPTION
Fixes: #163