### PR TITLE
Add backend for Nintendo Wii/GameCube 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ ELSEIF(CMAKE_SYSTEM_NAME MATCHES "NintendoWii|NintendoGameCube")
         src/ogc/fg_structure_ogc.c
         src/ogc/fg_window_ogc.c
     )
+    LIST(APPEND LIBS wiikeyboard fat)
     SET(FREEGLUT_BUILD_SHARED_LIBS OFF)
     # Only used in fg_window.c, to declare support for double buffering
     ADD_DEFINITIONS(-DEGL_VERSION_1_0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ SET(FREEGLUT_SRCS
     src/fg_window.c
 )
 # TODO: OpenGL ES requires a compatible version of these files:
-IF(NOT FREEGLUT_GLES)
+IF(NOT FREEGLUT_GLES AND NOT CMAKE_SYSTEM_NAME MATCHES "NintendoWii|NintendoGameCube")
     LIST(APPEND FREEGLUT_SRCS
         src/fg_font.c
         src/fg_menu.c
@@ -196,6 +196,27 @@ ELSEIF(ANDROID OR BLACKBERRY)
             src/blackberry/fg_window_blackberry.c
         )
     ENDIF()
+
+ELSEIF(CMAKE_SYSTEM_NAME MATCHES "NintendoWii|NintendoGameCube")
+
+    LIST(APPEND FREEGLUT_SRCS
+        src/ogc/fg_common_ogc.h
+        src/ogc/fg_cursor_ogc.c
+        src/ogc/fg_display_ogc.c
+        src/ogc/fg_ext_ogc.c
+        src/ogc/fg_gamemode_ogc.c
+        src/ogc/fg_init_ogc.c
+        src/ogc/fg_internal_ogc.h
+        src/ogc/fg_input_devices_ogc.c
+        src/ogc/fg_joystick_ogc.c
+        src/ogc/fg_main_ogc.c
+        src/ogc/fg_state_ogc.c
+        src/ogc/fg_structure_ogc.c
+        src/ogc/fg_window_ogc.c
+    )
+    SET(FREEGLUT_BUILD_SHARED_LIBS OFF)
+    # Only used in fg_window.c, to declare support for double buffering
+    ADD_DEFINITIONS(-DEGL_VERSION_1_0)
 
 ELSE()
     # UNIX (Wayland)

--- a/README.ogc
+++ b/README.ogc
@@ -1,0 +1,9 @@
+Freeglut on Wii/GameCube
+========================
+
+Build instructions
+------------------
+
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/Wii.cmake" -DFREEGLUT_BUILD_DEMOS=OFF ..

--- a/README.ogc
+++ b/README.ogc
@@ -1,9 +1,39 @@
-Freeglut on Wii/GameCube
-========================
+Freeglut on the Nintendo Wii/GameCube
+=====================================
+
+Supported features
+------------------
+
+- OpenGL via [opengx](https://github.com/devkitPro/opengx) (currently it's
+  a subset of OpenGL 1.1, newer versions will become available as opengx
+  evolves).
+- Filesystem support
+- USB keyboard support
+- GameCube controllers support
+- (Wii only) Wiimote support (without expansions)
+- (Wii only) Mouse emulation via Wiimote's IR
+
 
 Build instructions
 ------------------
 
-mkdir build
-cd build
-cmake -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/Wii.cmake" -DFREEGLUT_BUILD_DEMOS=OFF ..
+In order to build Freeglut for the Nintendo Wii or GameCube you need to install
+the [devkitPro](https://devkitpro.org/) toolchain, which provides the `pacman`
+command to install ready-built packages. Depending on your target console,
+install either the `wii-dev` or the `gamecube-dev` group, after which you can
+build the `opengx` project (which exports an OpenGL API on top of the console's
+GX API):
+
+    git clone https://github.com/devkitPro/opengx.git
+    cd opengx
+    mkdir build && cd build
+    # For the GameCube, use `GameCube.cmake` instead
+    cmake -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/Wii.cmake" ..
+    make && sudo make install
+
+You are now ready to build Freeglut. From the Freeglut top level directory,
+type these commands:
+
+    mkdir build && cd build
+    cmake -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/Wii.cmake" -DFREEGLUT_BUILD_DEMOS=OFF ..
+    make && sudo make install

--- a/src/fg_internal.h
+++ b/src/fg_internal.h
@@ -64,6 +64,9 @@
 #   define  TARGET_HOST_POSIX_X11  1
 /* #   define  TARGET_HOST_MAC_OSX    1 */
 
+#elif defined(__wii__) || defined(__gamecube__)
+#   define TARGET_HOST_OGC  1
+
 #else
 #   error "Unrecognized target host!"
 
@@ -101,6 +104,10 @@
 
 #ifndef  TARGET_HOST_SOLARIS
 #   define  TARGET_HOST_SOLARIS        0
+#endif
+
+#ifndef  TARGET_HOST_OGC
+#   define  TARGET_HOST_OGC            0
 #endif
 
 /* -- FIXED CONFIGURATION LIMITS ------------------------------------------- */
@@ -209,6 +216,9 @@
 #endif
 #if TARGET_HOST_BLACKBERRY
 #include "blackberry/fg_internal_blackberry.h"
+#endif
+#if TARGET_HOST_OGC
+#include "ogc/fg_internal_ogc.h"
 #endif
 
 

--- a/src/ogc/fg_common_ogc.h
+++ b/src/ogc/fg_common_ogc.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef FREEGLUT_COMMON_OGC_H
+#define FREEGLUT_COMMON_OGC_H
+
+#include <GL/freeglut.h>
+#include "../fg_internal.h"
+
+#endif /* FREEGLUT_COMMON_OGC_H */

--- a/src/ogc/fg_common_ogc.h
+++ b/src/ogc/fg_common_ogc.h
@@ -25,4 +25,21 @@
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
 
+#define MAX_GC_JOYSTICKS 4
+
+#ifdef __wii__
+#define MAX_WII_JOYSTICKS 4
+#else
+#define MAX_WII_JOYSTICKS 0
+#endif
+
+#define MAX_OGC_JOYSTICKS (MAX_GC_JOYSTICKS + MAX_WII_JOYSTICKS)
+
+extern void fghOnReshapeNotify(SFG_Window *window, int width, int height,
+                               GLboolean forceNotify);
+
+void fgOgcDisplaySetupVideoMode();
+void fgOgcDisplaySetupXfb();
+void fgOgcDisplayShowEFB();
+
 #endif /* FREEGLUT_COMMON_OGC_H */

--- a/src/ogc/fg_cursor_ogc.c
+++ b/src/ogc/fg_cursor_ogc.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformSetCursor(SFG_Window *window, int cursorID)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformWarpPointer(int x, int y)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fghPlatformGetCursorPos(const SFG_Window *window, GLboolean client, SFG_XYUse *mouse_pos)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_display_ogc.c
+++ b/src/ogc/fg_display_ogc.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformGlutSwapBuffers(SFG_PlatformDisplay *pDisplayPtr,
+                               SFG_Window *CurrentWindow)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_ext_ogc.c
+++ b/src/ogc/fg_ext_ogc.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+SFG_Proc fgPlatformGetProcAddress(const char *procName)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return NULL;
+}
+
+GLUTproc fgPlatformGetGLUTProcAddress(const char *procName)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return NULL;
+}
+

--- a/src/ogc/fg_ext_ogc.c
+++ b/src/ogc/fg_ext_ogc.c
@@ -23,13 +23,19 @@
 
 SFG_Proc fgPlatformGetProcAddress(const char *procName)
 {
-    fgWarning("%s() : not implemented", __func__);
+#define CHECK_NAME(x) if (strcmp(procName, #x) == 0) return (SFG_Proc)x
+    /* TODO: add functions here */
+#undef CHECK_NAME
+    fgWarning("%s() : not implemented (%s)", __func__, procName);
     return NULL;
 }
 
 GLUTproc fgPlatformGetGLUTProcAddress(const char *procName)
 {
-    fgWarning("%s() : not implemented", __func__);
+    if (strncmp(procName, "glut", 4) != 0)
+        return NULL;
+
+    fgWarning("%s() : not implemented (%s)", __func__, procName);
     return NULL;
 }
 

--- a/src/ogc/fg_gamemode_ogc.c
+++ b/src/ogc/fg_gamemode_ogc.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformRememberState(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformRestoreState(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+GLvoid fgPlatformGetGameModeVMaxExtent(SFG_Window *window, int *x, int *y)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+GLboolean fgPlatformChangeDisplayMode(GLboolean haveToTest)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return GL_FALSE;
+}
+
+
+void fgPlatformEnterGameMode(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformLeaveGameMode(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_init_ogc.c
+++ b/src/ogc/fg_init_ogc.c
@@ -21,9 +21,30 @@
 
 #include "fg_common_ogc.h"
 
+#include <fat.h>
+#include <malloc.h>
+#include <opengx.h>
+
+#define FIFO_SIZE (256*1024)
+
 void fgPlatformInitialize(const char *displayName)
 {
-    fgWarning("%s() : not implemented", __func__);
+    VIDEO_Init();
+
+    void *fifoBuffer = MEM_K0_TO_K1(memalign(32, FIFO_SIZE));
+    memset(fifoBuffer, 0, FIFO_SIZE);
+
+    GX_Init(fifoBuffer, FIFO_SIZE);
+    fgDisplay.pDisplay.vmode = VIDEO_GetPreferredMode(NULL);
+    fgOgcDisplaySetupVideoMode();
+
+    ogx_initialize();
+
+    fatInitDefault();
+
+    fgState.Time = fgSystemTime();
+    fgState.FPSInterval = 2000;
+    fgState.Initialised = GL_TRUE;
 }
 
 void fgPlatformDeinitialiseInputDevices(void)

--- a/src/ogc/fg_init_ogc.c
+++ b/src/ogc/fg_init_ogc.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformInitialize(const char *displayName)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformDeinitialiseInputDevices(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformCloseDisplay(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformDestroyContext(SFG_PlatformDisplay pDisplay,
+                              SFG_WindowContextType MContext)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_input_devices_ogc.c
+++ b/src/ogc/fg_input_devices_ogc.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformInitialiseInputDevices(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformCloseInputDevices(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformInitializeSpaceball(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformSpaceballClose(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformSpaceballSetWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+int fgPlatformHasSpaceball(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return 0;
+}
+
+int fgPlatformSpaceballNumButtons(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return 0;
+}
+
+typedef struct _serialport SERIALPORT;
+
+void fgPlatformRegisterDialDevice ( const char *dial_device ) {
+    fgWarning("GLUT_HAS_DIAL_AND_BUTTON_BOX: not implemented");
+}
+SERIALPORT *fg_serial_open (const char *device) { return NULL; }
+void fg_serial_close(SERIALPORT *port) {}
+int fg_serial_getchar(SERIALPORT *port) { return EOF; }
+int fg_serial_putchar(SERIALPORT *port, unsigned char ch) { return 0; }
+void fg_serial_flush(SERIALPORT *port) {}

--- a/src/ogc/fg_internal_ogc.h
+++ b/src/ogc/fg_internal_ogc.h
@@ -23,14 +23,22 @@
 #define FREEGLUT_INTERNAL_OGC_H
 
 /* -- PLATFORM-SPECIFIC INCLUDES ------------------------------------------- */
-/* TODO: add libogc and opengx */
+#include <ogc/gx.h>
+#include <ogc/gx_struct.h>
+#include <ogc/system.h>
+#include <ogc/video.h>
 
 /* -- GLOBAL TYPE DEFINITIONS ---------------------------------------------- */
 /* The structure used by display initialization in fg_init.c */
 typedef struct tagSFG_PlatformDisplay SFG_PlatformDisplay;
 struct tagSFG_PlatformDisplay
 {
-    bool unused;
+    /* The pointer(s) to the XFB(s). The second one can be NULL if double
+     * buffering is not used. */
+    void *xfb[2];
+    u8 fbIndex;
+    bool vmode_changed;
+    GXRModeObj *vmode;
 };
 
 /* The structure used by window creation in fg_window.c */
@@ -67,6 +75,7 @@ typedef uint32_t SFG_WindowColormapType;
 #define  FREEGLUT_MENU_PEN_HFORE_COLORS  {0.0f,  0.0f,  0.0f,  1.0f}
 #define  FREEGLUT_MENU_PEN_HBACK_COLORS  {1.0f,  1.0f,  1.0f,  1.0f}
 
-#define _JS_MAX_AXES  9
+#define _JS_MAX_AXES  4
+#define MAX_NUM_JOYSTICKS  8
 
 #endif /* FREEGLUT_INTERNAL_OGC_H */

--- a/src/ogc/fg_internal_ogc.h
+++ b/src/ogc/fg_internal_ogc.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef FREEGLUT_INTERNAL_OGC_H
+#define FREEGLUT_INTERNAL_OGC_H
+
+/* -- PLATFORM-SPECIFIC INCLUDES ------------------------------------------- */
+/* TODO: add libogc and opengx */
+
+/* -- GLOBAL TYPE DEFINITIONS ---------------------------------------------- */
+/* The structure used by display initialization in fg_init.c */
+typedef struct tagSFG_PlatformDisplay SFG_PlatformDisplay;
+struct tagSFG_PlatformDisplay
+{
+    bool unused;
+};
+
+/* The structure used by window creation in fg_window.c */
+typedef struct tagSFG_PlatformContext SFG_PlatformContext;
+struct tagSFG_PlatformContext
+{
+    bool unused;
+};
+
+/* The window state description. This structure should be kept portable. */
+typedef struct tagSFG_PlatformWindowState SFG_PlatformWindowState;
+struct tagSFG_PlatformWindowState
+{
+    bool unused;
+};
+
+
+typedef struct tagSFG_PlatformJoystick SFG_PlatformJoystick;
+struct tagSFG_PlatformJoystick
+{
+    bool unused;
+};
+
+/* Added just to make the lib compile. TODO: review the types. */
+typedef uint32_t SFG_WindowHandleType;
+typedef uint32_t SFG_WindowContextType;
+typedef uint32_t SFG_WindowColormapType;
+
+/* Menu font and color definitions */
+#define  FREEGLUT_MENU_FONT    NULL
+
+#define  FREEGLUT_MENU_PEN_FORE_COLORS   {0.0f,  0.0f,  0.0f,  1.0f}
+#define  FREEGLUT_MENU_PEN_BACK_COLORS   {0.70f, 0.70f, 0.70f, 1.0f}
+#define  FREEGLUT_MENU_PEN_HFORE_COLORS  {0.0f,  0.0f,  0.0f,  1.0f}
+#define  FREEGLUT_MENU_PEN_HBACK_COLORS  {1.0f,  1.0f,  1.0f,  1.0f}
+
+#define _JS_MAX_AXES  9
+
+#endif /* FREEGLUT_INTERNAL_OGC_H */

--- a/src/ogc/fg_joystick_ogc.c
+++ b/src/ogc/fg_joystick_ogc.c
@@ -21,19 +21,93 @@
 
 #include "fg_common_ogc.h"
 
+#include <wiiuse/wpad.h>
+
 void fgPlatformJoystickRawRead(SFG_Joystick *joy, int *buttons, float *axes)
 {
-    fgWarning("%s() : not implemented", __func__);
+    *buttons = 0;
+
+    if (joy->id < MAX_GC_JOYSTICKS) {
+        u16 btns = PAD_ButtonsHeld(joy->id);
+        if (btns & PAD_BUTTON_A) *buttons |= 0x1;
+        if (btns & PAD_BUTTON_B) *buttons |= 0x2;
+        if (btns & PAD_BUTTON_X) *buttons |= 0x4;
+        if (btns & PAD_BUTTON_Y) *buttons |= 0x8;
+        if (btns & PAD_TRIGGER_L) *buttons |= 0x10;
+        if (btns & PAD_TRIGGER_R) *buttons |= 0x20;
+        if (btns & PAD_TRIGGER_Z) *buttons |= 0x40;
+        if (btns & PAD_BUTTON_MENU) *buttons |= 0x80;
+        if (btns & PAD_BUTTON_START) *buttons |= 0x100;
+        axes[0] = PAD_StickX(joy->id) / 127.0;
+        axes[1] = PAD_StickY(joy->id) / 127.0;
+        axes[2] = PAD_SubStickX(joy->id) / 127.0;
+        axes[3] = PAD_SubStickY(joy->id) / 127.0;
+        return;
+    }
+
+#ifdef __wii__
+    int id = joy->id - MAX_GC_JOYSTICKS;
+    if (id < MAX_WII_JOYSTICKS) {
+        WPADData *data = WPAD_Data(id);
+        u32 btns = data->btns_h;
+        axes[0] = 0.0;
+        axes[1] = 0.0;
+        if (btns & WPAD_BUTTON_LEFT) axes[0] = -1.0;
+        if (btns & WPAD_BUTTON_RIGHT) axes[0] = 1.0;
+        if (btns & WPAD_BUTTON_UP) axes[1] = 1.0;
+        if (btns & WPAD_BUTTON_DOWN) axes[1] = -1.0;
+
+        if (btns & WPAD_BUTTON_1) *buttons |= 0x1;
+        if (btns & WPAD_BUTTON_2) *buttons |= 0x2;
+        if (btns & WPAD_BUTTON_A) *buttons |= 0x4;
+        if (btns & WPAD_BUTTON_B) *buttons |= 0x8;
+        if (btns & WPAD_BUTTON_MINUS) *buttons |= 0x10;
+        if (btns & WPAD_BUTTON_PLUS) *buttons |= 0x20;
+        if (btns & WPAD_BUTTON_HOME) *buttons |= 0x40;
+    }
+#endif
 }
 
 void fgPlatformJoystickOpen(SFG_Joystick *joy)
 {
-    fgWarning("%s() : not implemented", __func__);
+    fgWarning("%s() called for joystick %d", __func__, joy->id);
+    joy->error = GL_FALSE;
+    if (joy->id < MAX_GC_JOYSTICKS) {
+        sprintf(joy->name, "GameCube #%d", joy->id);
+        joy->num_axes = 4;
+        joy->num_buttons = 8;
+    } else {
+        sprintf(joy->name, "Wiimote #%d", joy->id - MAX_GC_JOYSTICKS);
+        joy->num_axes = 2;
+        joy->num_buttons = 7;
+    }
+
+    for (int i = 0; i < joy->num_axes; i++) {
+        joy->center[i] = 0.0;
+        joy->max[i] = 1.0;
+        joy->min[i] = -1.0;
+        joy->dead_band[i] = 0.0;
+        joy->saturate[i] = 1.0;
+    }
 }
 
 void fgPlatformJoystickInit(SFG_Joystick *fgJoystick[], int ident)
 {
-    fgWarning("%s() : not implemented", __func__);
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+
+        PAD_Init();
+        /* WPAD is initialized in fgPlatformMainLoopPreliminaryWork(), since
+         * it's used for mouse emulation as well. */
+    }
+
+    fgWarning("%s called for ident %d\n", __func__, ident);
+    if (ident < MAX_OGC_JOYSTICKS) {
+        SFG_Joystick *joy = fgJoystick[ident];
+        joy->id = ident;
+        joy->error = GL_FALSE;
+    }
 }
 
 void fgPlatformJoystickClose(int ident)

--- a/src/ogc/fg_joystick_ogc.c
+++ b/src/ogc/fg_joystick_ogc.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformJoystickRawRead(SFG_Joystick *joy, int *buttons, float *axes)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformJoystickOpen(SFG_Joystick *joy)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformJoystickInit(SFG_Joystick *fgJoystick[], int ident)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformJoystickClose(int ident)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_main_ogc.c
+++ b/src/ogc/fg_main_ogc.c
@@ -21,30 +21,234 @@
 
 #include "fg_common_ogc.h"
 
-fg_time_t fgPlatformSystemTime(void)
+#include <ogc/lwp_watchdog.h>
+#include <wiikeyboard/keyboard.h>
+#include <wiiuse/wpad.h>
+
+extern SFG_Joystick *fgJoystick[MAX_OGC_JOYSTICKS];
+
+static void keysym_to_utf8(uint16_t symbol, char *utf8)
 {
-    fgWarning("%s() : not implemented", __func__);
-    return 0;
+    /* ignore private symbols, used by wiikeyboard for special keys */
+    if ((symbol >= 0xE000 && symbol <= 0xF8FF) || symbol == 0xFFFF)
+        return;
+
+    /* convert UCS-2 to UTF-8 */
+    if (symbol < 0x80) {
+        utf8[0] = symbol;
+    } else if (symbol < 0x800) {
+        utf8[0] = 0xC0 | (symbol >> 6);
+        utf8[1] = 0x80 | (symbol & 0x3F);
+    } else {
+        utf8[0] = 0xE0 |  (symbol >> 12);
+        utf8[1] = 0x80 | ((symbol >> 6) & 0x3F);
+        utf8[2] = 0x80 |  (symbol & 0x3F);
+    }
 }
 
-void fgPlatformSleepForEvents(fg_time_t msec)
+static void processKeyboardEvent()
 {
-    fgWarning("%s() : not implemented", __func__);
+    SFG_Window* window = fgStructure.CurrentWindow;
+    FGCBKeyboardUC keyboard_cb;
+    FGCBSpecialUC special_cb;
+    FGCBUserData keyboard_ud;
+    FGCBUserData special_ud;
+    char string[4] = {'\0'};
+    int special = -1;
+    keyboard_event ke;
+
+    s32 res = KEYBOARD_GetEvent(&ke);
+    if (!res || (ke.type != KEYBOARD_RELEASED && ke.type != KEYBOARD_PRESSED))
+        return;
+
+    if (ke.type == KEYBOARD_PRESSED) {
+        fprintf(stderr, "Key pressed 0x%04x\n", (int)ke.symbol);
+        keyboard_cb = (FGCBKeyboardUC)(FETCH_WCB(*window, Keyboard));
+        special_cb  = (FGCBSpecialUC)(FETCH_WCB(*window, Special));
+        keyboard_ud = FETCH_USER_DATA_WCB(*window, Keyboard);
+        special_ud  = FETCH_USER_DATA_WCB(*window, Special);
+    } else {
+        keyboard_cb = (FGCBKeyboardUC)(FETCH_WCB(*window, KeyboardUp));
+        special_cb  = (FGCBSpecialUC)(FETCH_WCB(*window, SpecialUp));
+        keyboard_ud = FETCH_USER_DATA_WCB(*window, KeyboardUp);
+        special_ud  = FETCH_USER_DATA_WCB(*window, SpecialUp);
+    }
+
+    switch (ke.symbol) {
+    case KS_Up: special = GLUT_KEY_UP; break;
+    case KS_Down: special = GLUT_KEY_DOWN; break;
+    case KS_Left: special = GLUT_KEY_LEFT; break;
+    case KS_Right: special = GLUT_KEY_RIGHT; break;
+    case KS_Prior: special = GLUT_KEY_PAGE_UP; break;
+    case KS_Next: special = GLUT_KEY_PAGE_DOWN; break;
+    case KS_Home: special = GLUT_KEY_HOME; break;
+    case KS_End: special = GLUT_KEY_END; break;
+    case KS_Insert: special = GLUT_KEY_INSERT; break;
+    }
+    if (special == -1) {
+        if (ke.symbol >= KS_F1 && ke.symbol <= KS_F12) {
+            special = ke.symbol + GLUT_KEY_F1 - KS_F1;
+        } else if (ke.symbol >= KS_f1 && ke.symbol <= KS_f12) {
+            special = ke.symbol + GLUT_KEY_F1 - KS_f1;
+        }
+    }
+
+    if (special_cb && special != -1) {
+        special_cb(special, window->State.MouseX, window->State.MouseY, special_ud);
+    } else if (keyboard_cb && special == -1) {
+        unsigned char key = 0;
+        switch (ke.symbol) {
+        case KS_Return: key = '\n'; break;
+        case KS_Escape: key = 27; break;
+        default:
+            keysym_to_utf8(ke.symbol, string);
+            key = string[0];
+        }
+        keyboard_cb(key, window->State.MouseX, window->State.MouseY, keyboard_ud);
+    }
+}
+
+static void updateJoysticks()
+{
+    static u32 lastScanPads = 0;
+
+    if (fgState.JoysticksInitialised) {
+        lastScanPads = PAD_ScanPads();
+        for (int i = 0; i < MAX_GC_JOYSTICKS; i++) {
+            SFG_Joystick *joy = fgJoystick[i];
+            joy->error = !(lastScanPads & (1 << joy->id));
+        }
+    }
+
+#ifdef __wii__
+    /* The WPAD data is also used for the mouse, so we read it even if
+     * joysticks haven't been initialized */
+    WPAD_ScanPads();
+    WPAD_ReadPending(WPAD_CHAN_ALL, NULL);
+    if (fgState.JoysticksInitialised) {
+        for (int i = 0; i < MAX_WII_JOYSTICKS; i++) {
+            SFG_Joystick *joy = fgJoystick[i + MAX_GC_JOYSTICKS];
+            WPADData *data = WPAD_Data(i);
+            joy->error = data->err != WPAD_ERR_NONE || !data->data_present;
+        }
+    }
+#endif
+}
+
+/* We don't have a mouse-like device we can use on the GameCube. On the Wii,
+ * we'll use the first WiiMote IR. */
+#ifdef __wii__
+#define MAX_WII_MOUSE_BUTTONS 2
+
+static const struct {
+    int wii;
+    int mouse;
+} s_mouse_button_map[MAX_WII_MOUSE_BUTTONS] = {
+    { WPAD_BUTTON_B, GLUT_LEFT_BUTTON },
+    { WPAD_BUTTON_A, GLUT_RIGHT_BUTTON },
+};
+
+static void updateMouse()
+{
+    int oldX, oldY;
+    WPADData *data = WPAD_Data(0);
+    SFG_Window *window = fgStructure.CurrentWindow;
+    if (!window) return;
+
+    oldX = window->State.MouseX;
+    oldY = window->State.MouseY;
+    window->State.MouseX = data->ir.x * fgDisplay.ScreenWidth / 640;
+    window->State.MouseY = data->ir.y * fgDisplay.ScreenHeight / 480;
+
+    bool buttonPressed = false;
+    for (int b = 0; b < MAX_WII_MOUSE_BUTTONS; b++) {
+        if (data->btns_d & s_mouse_button_map[b].wii) {
+            INVOKE_WCB(*window, Mouse,
+                (s_mouse_button_map[b].mouse,
+                 GLUT_DOWN,
+                 window->State.MouseX,
+                 window->State.MouseY)
+            );
+        }
+        if (data->btns_u & s_mouse_button_map[b].wii) {
+            INVOKE_WCB(*window, Mouse,
+                (s_mouse_button_map[b].mouse,
+                 GLUT_UP,
+                 window->State.MouseX,
+                 window->State.MouseY)
+            );
+            buttonPressed = true;
+        }
+        if (data->btns_h & s_mouse_button_map[b].wii) {
+            buttonPressed = true;
+        }
+    }
+
+    if (oldX != window->State.MouseX || oldY != window->State.MouseY) {
+        if (buttonPressed) {
+            INVOKE_WCB(*window, Motion, (window->State.MouseX,
+                                         window->State.MouseY));
+        } else {
+            INVOKE_WCB(*window, Passive, (window->State.MouseX,
+                                          window->State.MouseY));
+        }
+    }
+}
+#endif
+
+fg_time_t fgPlatformSystemTime(void)
+{
+    return gettime() / TB_TIMER_CLOCK;
+}
+
+void fgPlatformSleepForEvents(fg_time_t ms)
+{
+    fgWarning("%s() : sleeping for %lld ms", __func__, ms);
+
+    /* FreeGlut does not offer a hook for redrawing the window in single-buffer
+     * mode, so let's to it here. */
+    if (!(fgState.DisplayMode & GLUT_DOUBLE)) {
+        fgOgcDisplayShowEFB();
+    }
+
+    struct timespec tv;
+    tv.tv_sec = ms / 1000;
+    tv.tv_nsec = (ms % 1000) * 1000000;
+    nanosleep(&tv, NULL);
 }
 
 void fgPlatformProcessSingleEvent(void)
 {
-    fgWarning("%s() : not implemented", __func__);
+    /* If an idle callback is specified, then fgPlatformSleepForEvents is not
+     * called, so we must find another place to render our scene (if using a
+     * single buffer). Let's do it here. */
+    if (fgState.IdleCallback && !(fgState.DisplayMode & GLUT_DOUBLE)) {
+        fgOgcDisplayShowEFB();
+    }
+
+    processKeyboardEvent();
+    updateJoysticks();
+#ifdef __wii__
+    updateMouse();
+#endif
 }
 
 void fgPlatformMainLoopPreliminaryWork(void)
 {
-    fgWarning("%s() : not implemented", __func__);
+    fgWarning("%s()", __func__);
+    KEYBOARD_Init(NULL);
+#ifdef __wii__
+    WPAD_Init();
+    WPAD_SetDataFormat(WPAD_CHAN_ALL, WPAD_FMT_BTNS_ACC_IR);
+    WPAD_SetVRes(WPAD_CHAN_ALL, 640, 480);
+#endif
 }
 
 void fgPlatformInitWork(SFG_Window *window)
 {
-    fgWarning("%s() : not implemented", __func__);
+    fghOnReshapeNotify(window,
+                       fgDisplay.ScreenWidth, fgDisplay.ScreenHeight,
+                       GL_FALSE);
 }
 
 void fgPlatformPosResZordWork(SFG_Window *window, unsigned int workMask)

--- a/src/ogc/fg_main_ogc.c
+++ b/src/ogc/fg_main_ogc.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+fg_time_t fgPlatformSystemTime(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return 0;
+}
+
+void fgPlatformSleepForEvents(fg_time_t msec)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformProcessSingleEvent(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformMainLoopPreliminaryWork(void)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformInitWork(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformPosResZordWork(SFG_Window *window, unsigned int workMask)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformVisibilityWork(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformSetColor(int idx, float r, float g, float b)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+float fgPlatformGetColor(int idx, int comp)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return 0.0;
+}
+
+void fgPlatformCopyColormap(int win)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_state_ogc.c
+++ b/src/ogc/fg_state_ogc.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+int fgPlatformGlutDeviceGet(GLenum eWhat)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return -1;
+}
+
+int fgPlatformGlutGet(GLenum eWhat)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return -1;
+}
+
+int *fgPlatformGlutGetModeValues(GLenum eWhat, int *size)
+{
+    fgWarning("%s() : not implemented", __func__);
+    return NULL;
+}

--- a/src/ogc/fg_structure_ogc.c
+++ b/src/ogc/fg_structure_ogc.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformCreateWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_window_ogc.c
+++ b/src/ogc/fg_window_ogc.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * MANUEL BACHMANN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fg_common_ogc.h"
+
+void fgPlatformSetWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformOpenWindow(SFG_Window *window, const char *title,
+                          GLboolean positionUse, int x, int y,
+                          GLboolean sizeUse, int w, int h,
+                          GLboolean gameMode, GLboolean isSubWindow)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformReshapeWindow(SFG_Window *window, int width, int height)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformCloseWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformShowWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformHideWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformIconifyWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformGlutSetWindowTitle(const char *title)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformGlutSetIconTitle(const char *title)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformPositionWindow(SFG_Window *window, int x, int y)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformPushWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformPopWindow(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}
+
+void fgPlatformFullScreenToggle(SFG_Window *window)
+{
+    fgWarning("%s() : not implemented", __func__);
+}

--- a/src/ogc/fg_window_ogc.c
+++ b/src/ogc/fg_window_ogc.c
@@ -23,7 +23,6 @@
 
 void fgPlatformSetWindow(SFG_Window *window)
 {
-    fgWarning("%s() : not implemented", __func__);
 }
 
 void fgPlatformOpenWindow(SFG_Window *window, const char *title,
@@ -31,7 +30,18 @@ void fgPlatformOpenWindow(SFG_Window *window, const char *title,
                           GLboolean sizeUse, int w, int h,
                           GLboolean gameMode, GLboolean isSubWindow)
 {
-    fgWarning("%s() : not implemented", __func__);
+    fgWarning("%s(): %d,%d - %dx%d", __func__, x, y, w, h);
+    /* We always ignore the requested size, we only support fullscreen windows
+     */
+    window->State.IsFullscreen = GL_TRUE;
+    window->State.Xpos = 0;
+    window->State.Ypos = 0;
+
+    window->State.WorkMask |= GLUT_INIT_WORK;
+    window->State.Visible = GL_TRUE;
+
+    /* This sets up the XFB for the chosen buffering scheme */
+    fgOgcDisplaySetupXfb();
 }
 
 void fgPlatformReshapeWindow(SFG_Window *window, int width, int height)


### PR DESCRIPTION
Depends on https://github.com/freeglut/freeglut/pull/165

Add a backend for the Nintendo Wii and GameCube consoles. Video, joysticks, keyboard and mouse (emulated using the Wiimote infrared pointer) work. I don't foresee the need to work on other features (though I might submit another PR later to draw the mouse cursor), but I will consider them if someone requests them.

And indeed, I volunteer to maintain this backend and to respond to bug reports as promptly as possible.

This PR is split in two commits, one where the backend is added as a stub, the other with the real implementation. Feel free to squash them, if you like (though keeping them separate might be of help to someone willing to write a new backend, because they could be used as a template).