### PR TITLE
ogc: clear frame buffer when setting a video mode

### DIFF
--- a/src/ogc/fg_display_ogc.c
+++ b/src/ogc/fg_display_ogc.c
@@ -21,6 +21,8 @@
 
 #include "fg_common_ogc.h"
 
+#include <ogc/color.h>
+
 void fgOgcDisplaySetupXfb()
 {
     GXRModeObj *vmode = fgDisplay.pDisplay.vmode;
@@ -53,6 +55,7 @@ void fgOgcDisplaySetupVideoMode()
     fgOgcDisplaySetupXfb();
 
     VIDEO_Configure(vmode);
+    VIDEO_ClearFrameBuffer(vmode, fgDisplay.pDisplay.xfb[0], COLOR_BLACK);
     VIDEO_SetNextFramebuffer(fgDisplay.pDisplay.xfb[0]);
     VIDEO_SetBlack(FALSE);
     VIDEO_Flush();


### PR DESCRIPTION
Without this, the screen shows green for a couple of seconds while the application starts.