### PR TITLE
ogc: don't show the mouse cursor if no callbacks were registered

### DIFF
--- a/src/ogc/fg_cursor_ogc.c
+++ b/src/ogc/fg_cursor_ogc.c
@@ -124,6 +124,10 @@ void fgOgcCursorDraw()
 
     if (!fgStructure.CurrentWindow) return;
 
+    /* Don't show a cursor if none of the mouse callback functions have been
+     * registered */
+    if (!FETCH_WCB(*window, Motion) && !FETCH_WCB(*window, Mouse)) return;
+
     cursorId = fgStructure.CurrentWindow->State.Cursor;
     for (i = 0; i < MAPPING_SIZE; i++) {
         CursorMapping *mapping = &cursor_mapping[i];


### PR DESCRIPTION
If neither glutMotionFunc() or glutMouseFunc() were called, we can safely assume that the application is not interested in mouse events. In this case, it's better to hide the mouse cursor otherwise the user might be led to think that mouse interaction is somehow possible.