### PR TITLE
ogc: let opengx know that we are about to swap buffers

### DIFF
--- a/src/ogc/fg_display_ogc.c
+++ b/src/ogc/fg_display_ogc.c
@@ -79,6 +79,8 @@ void fgOgcDisplayShowEFB()
     void *xfb;
     u8 mustClear, mustWait;
 
+    if (ogx_prepare_swap_buffers() < 0) return;
+
     fgOgcCursorDraw();
 
     if (fgState.DisplayMode & GLUT_DOUBLE) {


### PR DESCRIPTION
This is needed in order to support the GL_SELECT rendering mode (in that case, ogx_prepare_swap_buffers() will return a negative number), and generally to let opengx restore the embedded frame buffer state, in case it had been setup in some special mode.