### PR TITLE
ogc: add missing include

### DIFF
--- a/src/ogc/fg_display_ogc.c
+++ b/src/ogc/fg_display_ogc.c
@@ -22,6 +22,7 @@
 #include "fg_common_ogc.h"
 
 #include <ogc/color.h>
+#include <opengx.h>
 
 void fgOgcDisplaySetupXfb()
 {


### PR DESCRIPTION
This fixes an implicit declaration warning.