### PR TITLE
ogc: invoke visibility callback

### DIFF
--- a/src/ogc/fg_main_ogc.c
+++ b/src/ogc/fg_main_ogc.c
@@ -261,7 +261,7 @@ void fgPlatformPosResZordWork(SFG_Window *window, unsigned int workMask)
 
 void fgPlatformVisibilityWork(SFG_Window *window)
 {
-    fgWarning("%s() : not implemented", __func__);
+    INVOKE_WCB(*window, WindowStatus, (GLUT_FULLY_RETAINED));
 }
 
 void fgPlatformSetColor(int idx, float r, float g, float b)

--- a/src/ogc/fg_window_ogc.c
+++ b/src/ogc/fg_window_ogc.c
@@ -37,7 +37,7 @@ void fgPlatformOpenWindow(SFG_Window *window, const char *title,
     window->State.Xpos = 0;
     window->State.Ypos = 0;
 
-    window->State.WorkMask |= GLUT_INIT_WORK;
+    window->State.WorkMask |= GLUT_INIT_WORK | GLUT_VISIBILITY_WORK;
     window->State.Visible = GL_TRUE;
 
     /* This sets up the XFB for the chosen buffering scheme */


### PR DESCRIPTION
Our window is always visible, so emit the callback as soon as a window is created.