### PR TITLE
freeglut_std.h: don't use X11 fonts when building with devkitPro

### DIFF
--- a/include/GL/freeglut_std.h
+++ b/include/GL/freeglut_std.h
@@ -217,7 +217,7 @@
  *
  * Steve Baker suggested to make it binary compatible with GLUT:
  */
-#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__WATCOMC__)
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__WATCOMC__) || defined(__DEVKITPRO__)
 #   define  GLUT_STROKE_ROMAN               ((void *)0x0000)
 #   define  GLUT_STROKE_MONO_ROMAN          ((void *)0x0001)
 #   define  GLUT_BITMAP_9_BY_15             ((void *)0x0002)


### PR DESCRIPTION
This fixes an issue uncovered when building an application using the GLUT_BITMAP_* constants under the Nintendo Wii: freeglut_std.h was defining these constants to point to the variables defined in the X11 font module.

We fix this by checking for the presence of the __DEVKITPRO__ macro, which is a macro always defined when using the GCC built by the devkitPro distribution. Since this is a distribution meant for gaming consoles, we can be sure that X11 is not available there, so let's use the fonts embedded in freeglut.