### PR TITLE
build: revert GameCube/Wii hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ SET(FREEGLUT_SRCS
     src/fg_window.c
 )
 # TODO: OpenGL ES requires a compatible version of these files:
-IF(NOT FREEGLUT_GLES AND NOT OGC)
+IF(NOT FREEGLUT_GLES)
     LIST(APPEND FREEGLUT_SRCS
         src/fg_font.c
         src/fg_menu.c


### PR DESCRIPTION
This condition was added when we first added support for the GameCube & Wii consoles because at that time the opengx library did not support glBitmap(). Now that support is there, these files build just fine.

(I verified that fonts do get pronted correctly, as for menus I didn't find a suitable test yet -- but since they just use basic GL functions, I assume they should be working too)