### PR TITLE
egl: fix fgPlatformDestroyContext prototype for C23

### DIFF
--- a/src/egl/fg_init_egl.h
+++ b/src/egl/fg_init_egl.h
@@ -28,6 +28,6 @@
 
 extern void fghPlatformInitializeEGL();
 extern void fghPlatformCloseDisplayEGL();
-extern void fgPlatformDestroyContext();
+extern void fgPlatformDestroyContext ( SFG_PlatformDisplay pDisplay, SFG_WindowContextType MContext );
 
 #endif


### PR DESCRIPTION
C23 removes unprototyped functions, so this conflicted with the definition in fg_init_x11.c.

Bug: https://github.com/freeglut/freeglut/issues/186