### PR TITLE
macOS: Update Lorenz demo to run on macOS (Cocoa)

### DIFF
--- a/progs/demos/Lorenz/lorenz.c
+++ b/progs/demos/Lorenz/lorenz.c
@@ -341,11 +341,6 @@ int main ( int argc, char *argv[] )
   /* Initialize the random number generator */
   srand ( 1023 ) ;
 
-  /* Set up the OpenGL parameters */
-  glEnable ( GL_DEPTH_TEST ) ;
-  glClearColor ( 0.0, 0.0, 0.0, 0.0 ) ;
-  glClearDepth ( 1.0 ) ;
-
   /* Initialize GLUT */
   glutInitWindowSize ( 600, 600 ) ;
   glutInit ( &pargc, argv ) ;
@@ -359,6 +354,11 @@ int main ( int argc, char *argv[] )
   glutDisplayFunc ( display_cb ) ;
   glutReshapeFunc ( reshape_cb ) ;
   glutTimerFunc ( 30, timer_cb, 0 ) ;
+
+  /* Set up the OpenGL parameters */
+  glEnable ( GL_DEPTH_TEST ) ;
+  glClearColor ( 0.0, 0.0, 0.0, 0.0 ) ;
+  glClearDepth ( 1.0 ) ;
 
   /* Initialize the attractor:  The easiest way is to call the keyboard callback with an
    * argument of 'r' for Reset.


### PR DESCRIPTION
Only call OpenGL functions after glutInit/glutCreateWindow.

In Cocoa the OpenGL context is only created during windows creation (glutCreateWindow)