### PR TITLE
build: remove strict-prototype warnings

### DIFF
--- a/include/GL/freeglut_ext.h
+++ b/include/GL/freeglut_ext.h
@@ -214,7 +214,7 @@ FGAPI void    FGAPIENTRY glutSolidTeaspoon( double size );
 /*
  * Extension functions, see fg_ext.c
  */
-typedef void (*GLUTproc)( void );
+typedef void (*GLUTproc)();
 FGAPI GLUTproc FGAPIENTRY glutGetProcAddress( const char *procName );
 
 /*

--- a/include/GL/freeglut_ext.h
+++ b/include/GL/freeglut_ext.h
@@ -214,7 +214,7 @@ FGAPI void    FGAPIENTRY glutSolidTeaspoon( double size );
 /*
  * Extension functions, see fg_ext.c
  */
-typedef void (*GLUTproc)();
+typedef void (*GLUTproc)( void );
 FGAPI GLUTproc FGAPIENTRY glutGetProcAddress( const char *procName );
 
 /*

--- a/src/egl/fg_init_egl.c
+++ b/src/egl/fg_init_egl.c
@@ -30,7 +30,7 @@
 /*
  * A call to this function should initialize all the display stuff...
  */
-void fghPlatformInitializeEGL()
+void fghPlatformInitializeEGL( void )
 {
   /* CreateDisplay */
   /* Using EGL_DEFAULT_DISPLAY, or a specific native display */
@@ -59,7 +59,7 @@ void fghPlatformInitializeEGL()
   /* fgDisplay.ScreenHeightMM = ...; */
 }
 
-void fghPlatformCloseDisplayEGL()
+void fghPlatformCloseDisplayEGL( void )
 {
   if (fgDisplay.pDisplay.egl.Display != EGL_NO_DISPLAY) {
     eglTerminate(fgDisplay.pDisplay.egl.Display);

--- a/src/egl/fg_init_egl.h
+++ b/src/egl/fg_init_egl.h
@@ -26,8 +26,8 @@
 #ifndef __FG_INIT_EGL_H__
 #define __FG_INIT_EGL_H__
 
-extern void fghPlatformInitializeEGL();
-extern void fghPlatformCloseDisplayEGL();
+extern void fghPlatformInitializeEGL( void );
+extern void fghPlatformCloseDisplayEGL( void );
 extern void fgPlatformDestroyContext ( SFG_PlatformDisplay pDisplay, SFG_WindowContextType MContext );
 
 #endif

--- a/src/fg_gl2.c
+++ b/src/fg_gl2.c
@@ -59,7 +59,7 @@ void FGAPIENTRY glutSetVertexAttribTexCoord2(GLint attrib) {
 #define LOADFUNC(ptr, type, name)	\
 	do { if(!(ptr = (type)glutGetProcAddress(name))) return; } while(0)
 
-void fgInitGL2() {
+void fgInitGL2( void ) {
 #ifdef GL_ES_VERSION_2_0
     fgState.HasOpenGL20 = (fgState.MajorVersion >= 2);
 #else

--- a/src/fg_gl2.h
+++ b/src/fg_gl2.h
@@ -77,6 +77,6 @@ extern FGH_PFNGLVERTEXATTRIBPOINTERPROC fghVertexAttribPointer;
 
 #    endif
 
-extern void fgInitGL2();
+extern void fgInitGL2( void );
 
 #endif

--- a/src/fg_internal.h
+++ b/src/fg_internal.h
@@ -573,7 +573,7 @@ struct tagSFG_WindowState   /* as per notes above, sizes always refer to the cli
  * defined in freeglut_ext.h, but if we include that header in this file
  * a bunch of other stuff (font-related) blows up!
  */
-typedef void (*SFG_Proc)();
+typedef void (*SFG_Proc)( void );
 
 
 /*
@@ -1079,7 +1079,7 @@ void        fgOpenWindow( SFG_Window* window, const char* title,
                           GLboolean gameMode, GLboolean isSubWindow );
 void        fgCloseWindow( SFG_Window* window );
 void        fgAddToWindowDestroyList ( SFG_Window* window );
-void        fgCloseWindows ();
+void        fgCloseWindows ( void );
 void        fgDestroyWindow( SFG_Window* window );
 
 /* Menu creation and destruction. Defined in fg_structure.c */
@@ -1149,7 +1149,7 @@ SFG_Menu* fgMenuByID( int menuID );
  * Returns active menu, if any. Assumption: only one menu active throughout application at any one time.
  * This is easier than fgWindowByXXX as all menus are placed in one doubly linked list...
  */
-SFG_Menu* fgGetActiveMenu( );
+SFG_Menu* fgGetActiveMenu( void );
 
 /*
  * The menu activation and deactivation the code. This is the meat

--- a/src/fg_structure.c
+++ b/src/fg_structure.c
@@ -192,7 +192,7 @@ void fgAddToWindowDestroyList( SFG_Window* window )
 /*
  * Function to close down all the windows in the "WindowsToDestroy" list
  */
-void fgCloseWindows( )
+void fgCloseWindows( void )
 {
     while( fgStructure.WindowsToDestroy.First )
     {
@@ -598,7 +598,7 @@ static void fghcbGetActiveMenu( SFG_Menu *menu,
  * This is false when a submenu is also open.
  * This is easier than fgWindowByXXX as all menus are placed in one doubly linked list...
  */
-SFG_Menu* fgGetActiveMenu( )
+SFG_Menu* fgGetActiveMenu( void )
 {
     SFG_Enumerator enumerator;
 


### PR DESCRIPTION
Removes these types of warnings:
 - `warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`

Test builds ran:
 - `CFLAGS="-Wall -Wpedantic"  cmake -DCMAKE_BUILD_TYPE=Debug .. && make clean && make`
 - `CFLAGS="-std=gnu89 -Wall -Wpedantic" cmake -DCMAKE_BUILD_TYPE=Debug .. && make clean && make`