### PR TITLE
cocoa: Implement VSync with CVDisplayLink

### DIFF
--- a/src/cocoa/fg_display_cocoa.m
+++ b/src/cocoa/fg_display_cocoa.m
@@ -20,15 +20,65 @@
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
 
+#include <pthread.h>
+
 #import <Cocoa/Cocoa.h>
+
+extern BOOL shouldQuit;
+
+static pthread_mutex_t swapMutex  = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  swapCond   = PTHREAD_COND_INITIALIZER;
+static BOOL            frameReady = NO; /* synchronized by swapMutex */
+
+/*
+ * The display link callback is called when the display is refreshed, indicating that it is s
+ */
+CVReturn fgDisplayLinkCallback( CVDisplayLinkRef displayLink,
+    const CVTimeStamp                           *now,
+    const CVTimeStamp                           *outputTime,
+    CVOptionFlags                                flagsIn,
+    CVOptionFlags                               *flagsOut,
+    void                                        *displayLinkContext )
+{
+    static uint64_t FGUNUSED frameCount = 0;
+
+    pthread_mutex_lock( &swapMutex );
+#ifdef REPORT_DROPPED_FRAMES
+    static uint64_t dropped = 0;
+    if ( !frameReady ) {
+        DBG( "Dropped frame %llu - displayLinkCallback, no frame ready, %llu drops", frameCount, dropped );
+        dropped++;
+    }
+    else
+#endif
+    {
+        frameReady = false;
+        pthread_cond_signal( &swapCond ); // Wake the main thread
+    }
+    pthread_mutex_unlock( &swapMutex );
+
+    frameCount++;
+    return kCVReturnSuccess;
+}
 
 void fgPlatformGlutSwapBuffers( SFG_PlatformDisplay *pDisplayPtr, SFG_Window *CurrentWindow )
 {
-    PART_IMPL;
-    // Release the OpenGL context
-    NSOpenGLContext *context = (NSOpenGLContext *)CurrentWindow->Window.Context;
-    [context makeCurrentContext];
-    [context flushBuffer];
+    if ( pDisplayPtr->DisplayLink ) {
 
-    // TODO: Emulate VSync using CVDisplayLink
+        /*
+         * Emulate VSync using CVDisplayLink
+         */
+
+        pthread_mutex_lock( &swapMutex );
+        frameReady = true;
+        while ( frameReady && !shouldQuit ) {
+            pthread_cond_wait( &swapCond, &swapMutex ); // Wait for presentation from the display callback
+        }
+        pthread_mutex_unlock( &swapMutex );
+
+        /* The display just got refreshed, so we can swap the buffers */
+    }
+
+    NSOpenGLContext *context = (NSOpenGLContext *)CurrentWindow->Window.Context;
+    [context flushBuffer]; // Swap buffers to present the frame
 }

--- a/src/cocoa/fg_internal_cocoa.h
+++ b/src/cocoa/fg_internal_cocoa.h
@@ -23,6 +23,9 @@
 /* Add '#define DEBUG_LOG' for debug logging */
 #define UNIMPLEMENTED_WARNING
 
+/* Use CVDisplayLink for display synchronization */
+#define USE_CVDISPLAYLINK
+
 #include <unistd.h>
 
 #if defined( __GNUC__ ) && !defined( FGUNUSED )


### PR DESCRIPTION
Add display synchronization for macOS using CVDisplayLink to properly time buffer swaps with screen refresh. Implements thread synchronization with mutex/condition variables and configures the display link callback for windows with double buffering.

See PR #204 for demonstration