### PR TITLE
multi-touch demo: avoid direct inclusion of GL headers

### DIFF
--- a/progs/demos/multi-touch/multi-touch.c
+++ b/progs/demos/multi-touch/multi-touch.c
@@ -30,7 +30,6 @@
 #include <string.h>
 
 #include <GL/freeglut.h>
-#include <GL/gl.h>
 
 #define NUM_DEVICES 16
 #define NUM_CURSORS 64


### PR DESCRIPTION
On platforms like macOS, standard GL headers (e.g., GL/gl.h) may not be available.

Use freeglut.h, which handles the appropriate GL includes across platforms.