### PR TITLE
Macos improve window handling

### DIFF
--- a/src/cocoa/fg_init_cocoa.m
+++ b/src/cocoa/fg_init_cocoa.m
@@ -37,7 +37,7 @@ void fgPlatformInitialize( const char *displayName )
 
     // Get the main screen properties
     NSScreen *mainScreen   = [NSScreen mainScreen];
-    NSRect    screenFrame  = [mainScreen frame];
+    NSRect    screenFrame  = [mainScreen visibleFrame]; // visibleFrame excludes the menu bar and dock
     fgDisplay.ScreenWidth  = screenFrame.size.width;
     fgDisplay.ScreenHeight = screenFrame.size.height;
 

--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -670,6 +670,12 @@ void fgPlatformOpenWindow( SFG_Window *window,
             fgDisplay.pDisplay.DisplayLink, &fgDisplayLinkCallback, (__bridge void *)openGLView );
         CVDisplayLinkStart( fgDisplay.pDisplay.DisplayLink );
     }
+#else
+    // As of macOS 15, VSync is not functional, so CVDisplayLink is the recommended way to handle VSync
+
+    // Set the swap interval parameter
+    GLint swapInterval = 1; // 1 for VSync, 0 for no VSync
+    [glContext setValues:&swapInterval forParameter:NSOpenGLContextParameterSwapInterval];
 #endif
 
     DBG( "OpenGL Version: %s", glGetString( GL_VERSION ) );

--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -581,7 +581,11 @@ void fgPlatformOpenWindow( SFG_Window *window,
     // 2. Create fgOpenGLView with the pixel format
     //
 
-    NSRect        frame = NSMakeRect( positionUse ? x : 0, positionUse ? y : 0, sizeUse ? w : 300, sizeUse ? h : 300 );
+    // Flip y coordinate for OpenGL
+    y = positionUse ? fgDisplay.ScreenHeight - y - h : fgDisplay.ScreenHeight - h;
+    x = positionUse ? x : 0;
+
+    NSRect        frame      = NSMakeRect( x, y, sizeUse ? w : 300, sizeUse ? h : 300 );
     fgOpenGLView *openGLView = [[fgOpenGLView alloc] initWithFrame:frame pixelFormat:pixelFormat];
     if ( !openGLView ) {
         fgError( "Failed to create fgOpenGLView" );


### PR DESCRIPTION
This includes two changes:

#### Cocoa: Flip Y coordinate for OpenGL compatibility
OpenGL uses `(0,0)` as the bottom-left corner, whereas Cocoa uses the
top-left. Adjust coordinate origin to match OpenGL’s screen-space
convention.

#### Cocoa: report screen size excluding menu bar and dock
Use `[NSScreen visibleFrame]` instead of `[NSScreen frame]`.
This excludes the macOS menu bar and dock from the reported screen dimensions

#### Cocoa: Implement Offical VSync Support as Fallback
Add official VSync support for macOS via fallback mechanisms. Since the
official VSync support via swapInterval has been unreliable across
recent macOS releases (as OpenGL is deprecated on the platform), this
implementation still uses CVDisplayLink as the primary approach. The code allows for easy switching to the official swapInterval method
if/when Apple's OpenGL implementation stabilizes.
