### PR TITLE
Macos improve input handling

### DIFF
--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -80,6 +80,17 @@ BOOL shouldQuit = NO;
 
 @implementation fgOpenGLView
 
+/* Mac uses non-standard key codes, so we need to map them to GLUT key codes */
++ (uint16_t)convertFromMac:(uint16_t)key
+{
+    switch ( key ) {
+    case 0x7F:       // Delete
+        return 0x08; // Backspace
+    default:
+        return (uint16_t)key;
+    }
+}
+
 + (char)mapKeyToSpecial:(uint16_t)key
 {
     switch ( key ) {
@@ -388,9 +399,10 @@ BOOL shouldQuit = NO;
         return; // Ignore events with no characters
     }
 
-    unichar key       = [[event charactersIgnoringModifiers] characterAtIndex:0];
-    char    convKey   = [fgOpenGLView mapKeyToSpecial:key];
-    BOOL    isSpecial = ( convKey != key );
+    unichar key    = [[event charactersIgnoringModifiers] characterAtIndex:0];
+    key            = [fgOpenGLView convertFromMac:key];
+    char convKey   = [fgOpenGLView mapKeyToSpecial:key];
+    BOOL isSpecial = ( convKey != key );
 
     NSPoint mouseLoc = [self mouseLocation:event fromOutsideEvent:YES];
 
@@ -412,9 +424,10 @@ BOOL shouldQuit = NO;
         return; // Ignore events with no characters
     }
 
-    uint16_t key       = [[event charactersIgnoringModifiers] characterAtIndex:0];
-    char     convKey   = [fgOpenGLView mapKeyToSpecial:key];
-    BOOL     isSpecial = ( convKey != key );
+    uint16_t key   = [[event charactersIgnoringModifiers] characterAtIndex:0];
+    key            = [fgOpenGLView convertFromMac:key];
+    char convKey   = [fgOpenGLView mapKeyToSpecial:key];
+    BOOL isSpecial = ( convKey != key );
 
     NSPoint mouseLoc = [self mouseLocation:event fromOutsideEvent:YES];
 

--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -301,13 +301,11 @@ BOOL shouldQuit = NO;
     // TODO: Decide on a suitable threshold for scrolling events
     // Macos sends a lot of small delta values, so we need to filter them if we want to match the
     // behavior of other platforms
-    if ( fabs( bufferedY ) > fgWheelThreshold ) {
-        int direction = ( bufferedY > 0 ) ? GLUT_UP : GLUT_DOWN;
+    bufferedY += deltaY;
+    while ( fabs( bufferedY ) > fgWheelThreshold ) {
+        int direction = ( bufferedY > 0 ) ? 1 : -1;
         INVOKE_WCB( *self.fgWindow, MouseWheel, ( FG_MOUSE_WHEEL_Y, direction, mouseLoc.x, mouseLoc.y ) );
-        bufferedY = 0.0;
-    }
-    else {
-        bufferedY += deltaY;
+        bufferedY -= direction * fgWheelThreshold;
     }
 }
 


### PR DESCRIPTION
### Improve keyboard and mouse functionality

#### Cocoa: improve mouse wheel event handling
Enhance the scrollWheel method to properly handle large delta values by
calling the MouseWheel callback multiple times instead of discarding
excess movement.  This approach oreserves precise scrolling information
rather than truncating it.

Note that this may add some overhead if the user callback performs large
operations per invocation, though such implementations are generally
ill-advised.

#### Cocoa: add key code mapping between Mac and GLUT
Implement a key conversion function to properly handle Mac's
non-standard key codes and map them to their GLUT equivalents.

This improves cross-platform consistency by ensuring Mac-specific key
codes produce the same behavior as their equivalents on other platforms.