### PR TITLE
Update GitHub actions for macOS

### DIFF
--- a/.github/workflows/build_macosx_cocoa.yml
+++ b/.github/workflows/build_macosx_cocoa.yml
@@ -1,0 +1,34 @@
+name: MacOS X (Cocoa) build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: install dependencies
+      run: |
+        true
+
+    - name: generate makefile
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DFREEGLUT_BUILD_DEMOS=ON -DFREEGLUT_COCOA=ON .
+
+    - name: build freeglut
+      run: make
+
+    - name: stage install
+      run: DESTDIR=freeglut-instdir make install
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: freeglut-instdir
+        path: freeglut-instdir
+
+# vi:ts=2 sts=2 sw=2 expandtab:

--- a/.github/workflows/build_macosx_x11.yml
+++ b/.github/workflows/build_macosx_x11.yml
@@ -18,7 +18,7 @@ jobs:
         brew install xquartz libx11 libxi libxrandr libxxf86vm mesa
 
     - name: generate makefile
-      run: cmake -DCMAKE_BUILD_TYPE=Release -DFREEGLUT_BUILD_DEMOS=OFF -DOPENGL_gl_LIBRARY=/opt/homebrew/lib/libGL.dylib .
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DFREEGLUT_BUILD_DEMOS=ON -DFREEGLUT_COCOA=OFF -DOPENGL_gl_LIBRARY=/opt/homebrew/lib/libGL.dylib .
 
     - name: build freeglut
       run: make


### PR DESCRIPTION
This PR includes:
 - [CI: Enable building demo applications on macOS (X11)](https://github.com/freeglut/freeglut/commit/abca9e871f7301697064bdc037815cea0ee4ac0e)
 - [CI: Enable new macOS Cocoa build](https://github.com/freeglut/freeglut/commit/8a4f3705f056c3f34022fb92e4bcac3787829b41)

This fixes #212 