### PR TITLE
Cocoa: implement fgPlatformGlutDeviceGet and fgPlatformGlutGet

### DIFF
--- a/src/cocoa/fg_state_cocoa.m
+++ b/src/cocoa/fg_state_cocoa.m
@@ -20,20 +20,189 @@
 #include <GL/freeglut.h>
 #include "../fg_internal.h"
 
+#import <Cocoa/Cocoa.h>
+
 int fgPlatformGlutDeviceGet( GLenum eWhat )
 {
-    TODO_IMPL;
+    switch ( eWhat ) {
+    case GLUT_HAS_KEYBOARD:
+        return 1;
+
+    case GLUT_HAS_MOUSE:
+        return 1;
+
+    case GLUT_NUM_MOUSE_BUTTONS:
+        return 3; // left (click), middle (click+options), right (click+ctrl)
+
+    default:
+        fgWarning( "glutDeviceGet(): unhandled enum %d", eWhat );
+        break;
+    }
     return 0;
 }
 
 int fgPlatformGlutGet( GLenum eWhat )
 {
-    TODO_IMPL;
-    return 0;
+    NSWindow *win = (NSWindow *)fgStructure.CurrentWindow->Window.Handle;
+
+    switch ( eWhat ) {
+
+    case GLUT_WINDOW_X:
+    case GLUT_WINDOW_Y: {
+        NSRect frame   = [win frame];
+        NSRect content = [win contentRectForFrameRect:frame];
+        if ( eWhat == GLUT_WINDOW_X )
+            return content.origin.x;
+        else
+            return fgDisplay.ScreenHeight - content.origin.y - content.size.height;
+    }
+
+    case GLUT_WINDOW_BORDER_WIDTH:
+        /* Returns the width of the left or right border */
+        {
+            NSRect frame   = [win frame];
+            NSRect content = [win contentRectForFrameRect:frame];
+            /* Assume the left and right borders are the same size */
+            return ( frame.size.width - content.size.width ) / 2;
+        }
+
+    case GLUT_WINDOW_HEADER_HEIGHT:
+        /* Returns the height of the title bar */
+        {
+            NSRect frame   = [win frame];
+            NSRect content = [win contentRectForFrameRect:frame];
+            return frame.size.height - content.size.height;
+        }
+
+    case GLUT_WINDOW_WIDTH:
+    case GLUT_WINDOW_HEIGHT: {
+        NSRect frame = [win contentRectForFrameRect:[win frame]];
+        if ( eWhat == GLUT_WINDOW_WIDTH )
+            return frame.size.width;
+        else
+            return frame.size.height;
+    }
+
+    case GLUT_WINDOW_COLORMAP_SIZE:
+        /* macOS typically uses 32-bit RGBA color, so no color map */
+        return 0;
+
+    case GLUT_WINDOW_NUM_SAMPLES: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                samples     = 0;
+        [pixelFormat getValues:&samples forAttribute:NSOpenGLPFASamples forVirtualScreen:0];
+        return samples;
+    }
+
+    case GLUT_WINDOW_RGBA: {
+        /* All macOS contexts are RGBA */
+        return 1;
+    }
+
+    case GLUT_WINDOW_DOUBLEBUFFER: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                value       = 0;
+        [pixelFormat getValues:&value forAttribute:NSOpenGLPFADoubleBuffer forVirtualScreen:0];
+        return value;
+    }
+
+    case GLUT_WINDOW_BUFFER_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                colorSize   = 0;
+        [pixelFormat getValues:&colorSize forAttribute:NSOpenGLPFAColorSize forVirtualScreen:0];
+        return colorSize;
+    }
+
+    case GLUT_WINDOW_STENCIL_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                value       = 0;
+        [pixelFormat getValues:&value forAttribute:NSOpenGLPFAStencilSize forVirtualScreen:0];
+        return value;
+    }
+
+    case GLUT_WINDOW_DEPTH_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                value       = 0;
+        [pixelFormat getValues:&value forAttribute:NSOpenGLPFADepthSize forVirtualScreen:0];
+        return value;
+    }
+
+    case GLUT_WINDOW_RED_SIZE:
+    case GLUT_WINDOW_GREEN_SIZE:
+    case GLUT_WINDOW_BLUE_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                colorSize   = 0;
+        [pixelFormat getValues:&colorSize forAttribute:NSOpenGLPFAColorSize forVirtualScreen:0];
+        /* Assuming equal distribution for RGBA components */
+        return colorSize / 4;
+    }
+
+    case GLUT_WINDOW_ALPHA_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                value       = 0;
+        [pixelFormat getValues:&value forAttribute:NSOpenGLPFAAlphaSize forVirtualScreen:0];
+        return value;
+    }
+
+    case GLUT_WINDOW_ACCUM_RED_SIZE:
+    case GLUT_WINDOW_ACCUM_GREEN_SIZE:
+    case GLUT_WINDOW_ACCUM_BLUE_SIZE:
+    case GLUT_WINDOW_ACCUM_ALPHA_SIZE: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                accumSize   = 0;
+        [pixelFormat getValues:&accumSize forAttribute:NSOpenGLPFAAccumSize forVirtualScreen:0];
+        /* Assuming equal distribution for RGBA components in accumulation buffer */
+        return accumSize / 4;
+    }
+
+    case GLUT_WINDOW_STEREO: {
+        NSOpenGLPixelFormat *pixelFormat = fgStructure.CurrentWindow->Window.pContext.PixelFormat;
+        GLint                value       = 0;
+        [pixelFormat getValues:&value forAttribute:NSOpenGLPFAStereo forVirtualScreen:0];
+        return value;
+    }
+
+    case GLUT_WINDOW_CURSOR: {
+        return fgStructure.CurrentWindow->State.Cursor;
+    }
+
+    case GLUT_WINDOW_SRGB: {
+        /* macOS does not have a specific sRGB flag */
+        return 0;
+    }
+    case GLUT_DISPLAY_MODE_POSSIBLE:
+        /* TODO: Query fgState.ContextFlags to determine if display mode config is possible for now assume it is */
+        return 1;
+
+    case GLUT_WINDOW_FORMAT_ID:
+        /* macOS does not have a specific format ID */
+        return 0;
+
+    default:
+        fgWarning( "glutGet(): missing enum handle %d", eWhat );
+        break;
+    }
+
+    return -1;
 }
 
-int* fgPlatformGlutGetModeValues( GLenum eWhat, int* size )
+int *fgPlatformGlutGetModeValues( GLenum eWhat, int *size )
 {
-    TODO_IMPL;
+    /*
+     * There is no documentation for this function in the freeglut API, nor is
+     * it used in the test suite.  It seems to be a way to get a list of values
+     * for a given mode.  The size parameter is set to the number of values
+     * returned.  The return value is a pointer to an array of integers.
+     */
+
+    NO_IMPL;
+
+    switch ( eWhat ) {
+    case GLUT_AUX:
+    case GLUT_MULTISAMPLE:
+    default:
+        fgWarning( "glutGetModeValues: not implemented for %d", eWhat );
+        break;
+    }
     return NULL;
 }

--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -552,6 +552,8 @@ void fgPlatformOpenWindow( SFG_Window *window,
     //
     // 1. Define pixel format attributes based on fgState.DisplayMode
     //
+    // TODO: Move this to a separate function to support fgPlatformGlutGet(GLUT_DISPLAY_MODE_POSSIBLE)
+    //
 
     NSOpenGLPixelFormatAttribute attrs[32];
     int                          attrIndex = 0;


### PR DESCRIPTION
 - Implements fgPlatformGlutDeviceGet to report keyboard/mouse availability and buttons
 - Implements fgPlatformGlutGet with comprehensive support for window properties
 - Adds placeholder for fgPlatformGlutGetModeValues with NO_IMPL marker
 - Adds TODO comment for refactoring pixel format creation logic to support GLUT_DISPLAY_MODE_POSSIBLE

part of #195

Tested with this sample application:

```c
#include <GL/freeglut.h>
#include <stdio.h>

void display() {
    glClear(GL_COLOR_BUFFER_BIT);

    printf("GLUT_WINDOW_X: %d\n", glutGet(GLUT_WINDOW_X));
    printf("GLUT_WINDOW_Y: %d\n", glutGet(GLUT_WINDOW_Y));
    printf("GLUT_WINDOW_BORDER_WIDTH: %d\n", glutGet(GLUT_WINDOW_BORDER_WIDTH));
    printf("GLUT_WINDOW_HEADER_HEIGHT: %d\n", glutGet(GLUT_WINDOW_HEADER_HEIGHT));
    printf("GLUT_WINDOW_WIDTH: %d\n", glutGet(GLUT_WINDOW_WIDTH));
    printf("GLUT_WINDOW_HEIGHT: %d\n", glutGet(GLUT_WINDOW_HEIGHT));
    printf("GLUT_WINDOW_COLORMAP_SIZE: %d\n", glutGet(GLUT_WINDOW_COLORMAP_SIZE));
    printf("GLUT_WINDOW_NUM_SAMPLES: %d\n", glutGet(GLUT_WINDOW_NUM_SAMPLES));
    printf("GLUT_WINDOW_RGBA: %d\n", glutGet(GLUT_WINDOW_RGBA));
    printf("GLUT_WINDOW_DOUBLEBUFFER: %d\n", glutGet(GLUT_WINDOW_DOUBLEBUFFER));
    printf("GLUT_WINDOW_BUFFER_SIZE: %d\n", glutGet(GLUT_WINDOW_BUFFER_SIZE));
    printf("GLUT_WINDOW_STENCIL_SIZE: %d\n", glutGet(GLUT_WINDOW_STENCIL_SIZE));
    printf("GLUT_WINDOW_DEPTH_SIZE: %d\n", glutGet(GLUT_WINDOW_DEPTH_SIZE));
    printf("GLUT_WINDOW_RED_SIZE: %d\n", glutGet(GLUT_WINDOW_RED_SIZE));
    printf("GLUT_WINDOW_GREEN_SIZE: %d\n", glutGet(GLUT_WINDOW_GREEN_SIZE));
    printf("GLUT_WINDOW_BLUE_SIZE: %d\n", glutGet(GLUT_WINDOW_BLUE_SIZE));
    printf("GLUT_WINDOW_ALPHA_SIZE: %d\n", glutGet(GLUT_WINDOW_ALPHA_SIZE));
    printf("GLUT_WINDOW_ACCUM_RED_SIZE: %d\n", glutGet(GLUT_WINDOW_ACCUM_RED_SIZE));
    printf("GLUT_WINDOW_ACCUM_GREEN_SIZE: %d\n", glutGet(GLUT_WINDOW_ACCUM_GREEN_SIZE));
    printf("GLUT_WINDOW_ACCUM_BLUE_SIZE: %d\n", glutGet(GLUT_WINDOW_ACCUM_BLUE_SIZE));
    printf("GLUT_WINDOW_ACCUM_ALPHA_SIZE: %d\n", glutGet(GLUT_WINDOW_ACCUM_ALPHA_SIZE));
    printf("GLUT_WINDOW_STEREO: %d\n", glutGet(GLUT_WINDOW_STEREO));
    printf("GLUT_WINDOW_SRGB: %d\n", glutGet(GLUT_WINDOW_SRGB));
    printf("GLUT_DISPLAY_MODE_POSSIBLE: %d\n", glutGet(GLUT_DISPLAY_MODE_POSSIBLE));
    printf("GLUT_WINDOW_FORMAT_ID: %d\n", glutGet(GLUT_WINDOW_FORMAT_ID));

    glutSwapBuffers();
}

int main(int argc, char **argv) {
    glutInit(&argc, argv);
    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA | GLUT_DEPTH | GLUT_STENCIL | GLUT_ACCUM |
                        GLUT_ALPHA | GLUT_MULTISAMPLE);
    glutInitWindowPosition(100, 100);
    glutInitWindowSize(800, 600);
    glutCreateWindow("GLUT Get Test");
    glutDisplayFunc(display);
    glutMainLoop();
    return 0;
}

```

Output:
```
GLUT_WINDOW_X: 100
GLUT_WINDOW_Y: 100
GLUT_WINDOW_BORDER_WIDTH: 0
GLUT_WINDOW_HEADER_HEIGHT: 28
GLUT_WINDOW_WIDTH: 800
GLUT_WINDOW_HEIGHT: 600
GLUT_WINDOW_COLORMAP_SIZE: 0
GLUT_WINDOW_NUM_SAMPLES: 4
GLUT_WINDOW_RGBA: 1
GLUT_WINDOW_DOUBLEBUFFER: 1
GLUT_WINDOW_BUFFER_SIZE: 32
GLUT_WINDOW_STENCIL_SIZE: 8
GLUT_WINDOW_DEPTH_SIZE: 32
GLUT_WINDOW_RED_SIZE: 8
GLUT_WINDOW_GREEN_SIZE: 8
GLUT_WINDOW_BLUE_SIZE: 8
GLUT_WINDOW_ALPHA_SIZE: 8
GLUT_WINDOW_ACCUM_RED_SIZE: 32
GLUT_WINDOW_ACCUM_GREEN_SIZE: 32
GLUT_WINDOW_ACCUM_BLUE_SIZE: 32
GLUT_WINDOW_ACCUM_ALPHA_SIZE: 32
GLUT_WINDOW_STEREO: 0
GLUT_WINDOW_SRGB: 0
GLUT_DISPLAY_MODE_POSSIBLE: 1
GLUT_WINDOW_FORMAT_ID: 0
```