### PR TITLE
cocoa: fix incorrect draw buffer state after window creation

### DIFF
--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -628,7 +628,7 @@ void fgPlatformOpenWindow( SFG_Window *window,
     window->Window.pContext.PixelFormat = pixelFormat;
 
     //
-    // 2. Create fgOpenGLView with the pixel format
+    // 2. Create fgOpenGLView without a pixel format (the pixel format is used later in step 5)
     //
 
     // Flip y coordinate for OpenGL
@@ -636,7 +636,7 @@ void fgPlatformOpenWindow( SFG_Window *window,
     x = positionUse ? x : 0;
 
     NSRect        frame      = NSMakeRect( x, y, sizeUse ? w : 300, sizeUse ? h : 300 );
-    fgOpenGLView *openGLView = [[fgOpenGLView alloc] initWithFrame:frame pixelFormat:pixelFormat];
+    fgOpenGLView *openGLView = [[fgOpenGLView alloc] initWithFrame:frame];
     if ( !openGLView ) {
         fgError( "Failed to create fgOpenGLView" );
     }
@@ -680,13 +680,14 @@ void fgPlatformOpenWindow( SFG_Window *window,
     [nsWindow setDelegate:delegate];
 
     //
-    // 5. Retrieve the NSOpenGLContext from the fgOpenGLView
+    // 5. Create NSOpenGLContext, and associate it with the view
     //
 
-    NSOpenGLContext *glContext = [openGLView openGLContext];
+    NSOpenGLContext *glContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
     if ( !glContext ) {
-        fgError( "Failed to retrieve NSOpenGLContext from fgOpenGLView" );
+        fgError( "Failed to create NSOpenGLContext" );
     }
+    [glContext setView:openGLView];
     window->Window.Context = glContext;
 
     //


### PR DESCRIPTION
tl;dr - Use explicit NSOpenGLContext creation on macOS

On macOS, the implicit `NSOpenGLContext` creation by `NSOpenGLView` could lead to a timing issue where the context was not yet associated with a ready drawable surface.

This would cause an incorrect state after `glutCreateWindow` returned, but before the first `reshape` or `display` callbacks were invoked. In this window, queries like `GL_DRAW_BUFFER` would incorrectly return `GL_NONE` (0). The issue was masked and corrected by subsequent callbacks in the main loop.

This change refactors the context creation to be explicit:

1.  The `fgOpenGLView` is created without an `NSOpenGLPixelFormat`.
2.  The `NSOpenGLContext` is created manually with the desired pixel format.
3.  The context is explicitly associated with the view using `[glContext setView:]`.

This more robust method, similar to that used by GLFW, ensures the context is valid from the moment it is first made current, resolving the initialization race condition.