### PR TITLE
docs: Convert API docs from PHP/HTML to Markdown

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1468,9 +1468,7 @@ constant values:
 
 The *updown* argument may take one of the two defined constant
 values:
-- 
-		GLUT_DOWN, GLUT_UP indicating if button is pressed or released.
-	
+- GLUT_DOWN, GLUT_UP indicating if button is pressed or released.
 
 **Changes From GLUT**
 

--- a/src/util/html2md.c
+++ b/src/util/html2md.c
@@ -667,9 +667,21 @@ void html_to_markdown(const char *html, StringBuilder *output, HeaderList *heade
 
                 in_list_item = true;
                 p = tag_end + 1;
+
+                // Skip leading whitespace after <li> tag
+                while (*p && isspace((unsigned char)*p)) {
+                    p++;
+                }
+
                 continue;
             }
             if (strncmp(tag, "</li>", 5) == 0) {
+                // Trim trailing whitespace before closing list item
+                while (output->size > 0 && isspace((unsigned char)output->text[output->size - 1])) {
+                    output->size--;
+                    output->text[output->size] = '\0';
+                }
+
                 sb_append(output, "\n");
                 in_list_item = false;
                 p = tag_end + 1;


### PR DESCRIPTION
Convert the FreeGLUT API documentation (docs/api.php) to Markdown format for improved portability and readability.

A custom HTML-to-Markdown converter (html2md.c) was developed to handle the specific structure of the FreeGLUT documentation, including:
- Conversion of `<tt>` tags to inline code or code blocks
- Proper paragraph spacing with `</p>` tag handling
- HTML entity conversion (`&nbsp;`, `&lt`;, `&gt;`, etc.)
- Header level mapping (H1→H2, H2→H3, H3→H4)
- List formatting with proper indentation
- Automatic table of contents generation
- Multi-line code blocks for function signatures

The converter tool is included for future documentation updates.

**Note:**

Full disclosure, this was mostly done by claude code, I mainly reviewed the output and pointed out the issues. Rinse and repeat.

There remain a few minor formatting issues, but many of these are due to the variations in api.php and semantic differences in how php is rendered vs markdown.

**Usage:**
```
  gcc -o html2md html2md.c
  ./html2md --top-level-header "freeglut API" --skip-h1-header "Contents" \
             --generate-toc docs/api.php api.md
```

Related to #200