### PR TITLE
docs: mark unimplemented functions in man pages

### DIFF
--- a/man/glutEstablishOverlay.man
+++ b/man/glutEstablishOverlay.man
@@ -3,10 +3,12 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutEstablishOverlay 3 "April 2025" "freeglut" "freeglut"
+.TH glutEstablishOverlay 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutEstablishOverlay - establishes an overlay (if possible) for the
 current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutOverlayDisplayFunc.man
+++ b/man/glutOverlayDisplayFunc.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutOverlayDisplayFunc 3 "April 2025" "freeglut" "freeglut"
+.TH glutOverlayDisplayFunc 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutOverlayDisplayFunc - sets the overlay display callback for the current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutPostOverlayRedisplay.man
+++ b/man/glutPostOverlayRedisplay.man
@@ -3,11 +3,13 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutPostOverlayRedisplay 3 "April 2025" "freeglut" "freeglut"
+.TH glutPostOverlayRedisplay 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutPostOverlayRedisplay, glutPostWindowOverlayRedisplay - marks the
 overlay of the current or specified window as needing to be
 redisplayed.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutRemoveOverlay.man
+++ b/man/glutRemoveOverlay.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutRemoveLayer 3 "April 2025" "freeglut" "freeglut"
+.TH glutRemoveLayer 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutRemoveOverlay - removes the overlay (if one exists) from the current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutShowOverlay.man
+++ b/man/glutShowOverlay.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutShowOverlay 3 "April 2025" "freeglut" "freeglut"
+.TH glutShowOverlay 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutShowOverlay, glutHideOverlay - shows or hides the overlay of the current window
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutTabletButtonFunc.man
+++ b/man/glutTabletButtonFunc.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutTabletButtonFunc 3 "April 2025" "freeglut" "freeglut"
+.TH glutTabletButtonFunc 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutTabletButtonFunc - sets the special keyboard callback for the current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutTabletMotionFunc.man
+++ b/man/glutTabletMotionFunc.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutTabletMotionFunc 3 "April 2025" "freeglut" "freeglut"
+.TH glutTabletMotionFunc 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutTabletMotionFunc - sets the special keyboard callback for the current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutUseLayer.man
+++ b/man/glutUseLayer.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutUseLayer 3 "April 2025" "freeglut" "freeglut"
+.TH glutUseLayer 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutUseLayer - changes the layer in use for the current window.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP

--- a/man/glutVideoResizeGet.man
+++ b/man/glutVideoResizeGet.man
@@ -3,9 +3,11 @@
 .\"
 .\" See the file "man/LICENSE" for information on usage and redistribution
 .\"
-.TH glutVideoResizeGet 3 "April 2025" "freeglut" "freeglut"
+.TH glutVideoResizeGet 3 "November 2025" "freeglut" "freeglut"
 .SH NAME
 glutVideoResizeGet - retrieves GLUT video resize information represented by integers.
+.SH WARNING
+Not yet implemented in freeglut.
 .SH SYNTAX
 .nf
 .LP


### PR DESCRIPTION
Identified unimplemented functions from grepping api.md:

 - Added a warning header just above SYNTAX Section header
 - Also bump `.TH` dates from "April 2025" to "November 2025" for consistency.

**Method**
```sh
UNIMPLEMENTED='.SH WARNING\nNot yet implemented in freeglut.\n';
while read file;do
    echo "Updating $file..."
    sed -i '' 's|"April 2025"|"November 2025"|' $file
    sed -i '' "s|.SH SYNTAX|${UNIMPLEMENTED}&|" $file
done < adjusted-man
```

See also #249