### PR TITLE
cocoa: fix pixelFormat double free in subwindows

### DIFF
--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -1309,6 +1309,9 @@ void fgPlatformCloseWindow( SFG_Window *window )
         // TODO: we should probably remove all subviews left here incase the
         // subviews are torn down after the parent window. Dont forget to invalidate
         // all Children windows' pContext.View pointers too.
+        // TODO: Teardown currently depends on destruction order and is fragile.
+        // Consider revisiting resource ownership so subwindows retain references to
+        // top-level resources (e.g., pixelFormat, delegate).
 
         // CRITICAL: Detach the content view before closing the window.
         [nsWindow setContentView:nil];
@@ -1316,10 +1319,10 @@ void fgPlatformCloseWindow( SFG_Window *window )
         // Close the Window
         [nsWindow close];
         [delegate release];
+        [pixelFormat release];
     }
 
     [context release];
-    [pixelFormat release];
 
     window->Window.Handle               = nil;
     window->Window.Context              = nil;


### PR DESCRIPTION
Subwindows store a pointer to the top-level window's pixelFormat rather than owning a separate reference. Avoid freeing it from subwindow teardown, which could crash when subwindows are recreated while the top-level window remains alive.