### PR TITLE
cocoa: implement glutSetCursor for Cocoa backend

### DIFF
--- a/src/cocoa/fg_cursor_cocoa.m
+++ b/src/cocoa/fg_cursor_cocoa.m
@@ -62,9 +62,137 @@ void fghPlatformGetCursorPos( const SFG_Window *window, GLboolean client, SFG_XY
     mouse_pos->Use = GL_TRUE;
 }
 
+/*
+ * Cursor handling works through AppKit cursor rects: fgPlatformSetCursor
+ * stores the NSCursor for the window in pContext.Cursor, and the window's
+ * fgOpenGLView applies it from -resetCursorRects whenever the pointer is
+ * inside the view. A nil cursor means GLUT_CURSOR_INHERIT.
+ */
+
+/* A fully transparent cursor, for GLUT_CURSOR_NONE */
+static NSCursor *fghEmptyCursor( void )
+{
+    static NSCursor *empty = nil;
+
+    if ( !empty ) {
+        NSImage *blank = [[NSImage alloc] initWithSize:NSMakeSize( 16, 16 )];
+        empty          = [[NSCursor alloc] initWithImage:blank hotSpot:NSZeroPoint];
+        [blank release];
+    }
+    return empty;
+}
+
+/* Diagonal window-resize cursors only gained public API in macOS 15 */
+static NSCursor *fghCornerCursor( int cursorID )
+{
+#if defined( MAC_OS_VERSION_15_0 ) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_15_0
+    if ( @available( macOS 15.0, * ) ) {
+        NSCursorFrameResizePosition position;
+        switch ( cursorID ) {
+        case GLUT_CURSOR_TOP_LEFT_CORNER:
+            position = NSCursorFrameResizePositionTopLeft;
+            break;
+        case GLUT_CURSOR_TOP_RIGHT_CORNER:
+            position = NSCursorFrameResizePositionTopRight;
+            break;
+        case GLUT_CURSOR_BOTTOM_RIGHT_CORNER:
+            position = NSCursorFrameResizePositionBottomRight;
+            break;
+        default:
+            position = NSCursorFrameResizePositionBottomLeft;
+            break;
+        }
+        return [NSCursor frameResizeCursorFromPosition:position inDirections:NSCursorFrameResizeDirectionsAll];
+    }
+#endif
+    return [NSCursor crosshairCursor];
+}
+
+static NSCursor *fghCursorForID( int cursorID )
+{
+    switch ( cursorID ) {
+    case GLUT_CURSOR_RIGHT_ARROW: /* TODO: macOS has no mirrored arrow */
+    case GLUT_CURSOR_LEFT_ARROW:
+        return [NSCursor arrowCursor];
+    case GLUT_CURSOR_INFO:
+        return [NSCursor pointingHandCursor];
+    case GLUT_CURSOR_DESTROY:
+        return [NSCursor operationNotAllowedCursor];
+    case GLUT_CURSOR_HELP:  /* TODO: no public help/cycle/wait cursors; the system */
+    case GLUT_CURSOR_CYCLE: /* TODO: shows its own busy indicator when appropriate */
+    case GLUT_CURSOR_WAIT:
+        return [NSCursor arrowCursor];
+    case GLUT_CURSOR_SPRAY: /* TODO */
+    case GLUT_CURSOR_CROSSHAIR:
+    case GLUT_CURSOR_FULL_CROSSHAIR: /* FULL_CROSSHAIR demotes to CROSSHAIR, as on X11 */
+        return [NSCursor crosshairCursor];
+    case GLUT_CURSOR_TEXT:
+        return [NSCursor IBeamCursor];
+    case GLUT_CURSOR_UP_DOWN:
+        return [NSCursor resizeUpDownCursor];
+    case GLUT_CURSOR_LEFT_RIGHT:
+        return [NSCursor resizeLeftRightCursor];
+    case GLUT_CURSOR_TOP_SIDE:
+        return [NSCursor resizeUpCursor];
+    case GLUT_CURSOR_BOTTOM_SIDE:
+        return [NSCursor resizeDownCursor];
+    case GLUT_CURSOR_LEFT_SIDE:
+        return [NSCursor resizeLeftCursor];
+    case GLUT_CURSOR_RIGHT_SIDE:
+        return [NSCursor resizeRightCursor];
+    case GLUT_CURSOR_TOP_LEFT_CORNER:
+    case GLUT_CURSOR_TOP_RIGHT_CORNER:
+    case GLUT_CURSOR_BOTTOM_RIGHT_CORNER:
+    case GLUT_CURSOR_BOTTOM_LEFT_CORNER:
+        return fghCornerCursor( cursorID );
+    case GLUT_CURSOR_NONE:
+        return fghEmptyCursor( );
+    case GLUT_CURSOR_INHERIT:
+        return nil;
+    default:
+        fgError( "Unknown cursor type: %d", cursorID );
+        return nil; /* not reached */
+    }
+}
+
+/* Walk up the window hierarchy to resolve GLUT_CURSOR_INHERIT (nil).
+ * Returns nil if no ancestor set a cursor, i.e. use the system default. */
+NSCursor *fghCocoaEffectiveCursor( const SFG_Window *window )
+{
+    for ( ; window; window = window->Parent ) {
+        NSCursor *cursor = (NSCursor *)window->Window.pContext.Cursor;
+        if ( cursor ) {
+            return cursor;
+        }
+    }
+    return nil;
+}
+
+/* Subwindows inheriting their cursor must re-resolve it too */
+static void fghInvalidateCursorRectsRecursive( SFG_Window *window )
+{
+    NSView *view = (NSView *)window->Window.pContext.View;
+    if ( view ) {
+        [[view window] invalidateCursorRectsForView:view];
+    }
+
+    SFG_Window *child;
+    for ( child = (SFG_Window *)window->Children.First; child; child = (SFG_Window *)child->Node.Next ) {
+        fghInvalidateCursorRectsRecursive( child );
+    }
+}
+
 void fgPlatformSetCursor( SFG_Window *window, int cursorID )
 {
-    TODO_IMPL;
+    AUTORELEASE_POOL;
+
+    NSCursor *cursor = fghCursorForID( cursorID );
+
+    [cursor retain];
+    [(NSCursor *)window->Window.pContext.Cursor release];
+    window->Window.pContext.Cursor = cursor;
+
+    fghInvalidateCursorRectsRecursive( window );
 }
 
 void fgPlatformWarpPointer( int x, int y )

--- a/src/cocoa/fg_internal_cocoa.h
+++ b/src/cocoa/fg_internal_cocoa.h
@@ -91,6 +91,7 @@ struct CocoaPlatformDisplay {
 struct CocoaPlatformContext {
     void *PixelFormat; /* Pixel format - NSOpenGLPixelFormat* */
     void *View;        /* This window or subwindow's view - NSOpenGLView* */
+    void *Cursor;      /* glutSetCursor cursor - NSCursor*, nil = GLUT_CURSOR_INHERIT */
 };
 
 /* Per NSWindow state info. Instanced only for new GLUT windows, referenced by subwindows */

--- a/src/cocoa/fg_window_cocoa.m
+++ b/src/cocoa/fg_window_cocoa.m
@@ -29,6 +29,8 @@ void fghOnPositionNotify( SFG_Window *window, int x, int y, GLboolean forceNotif
 void fghPlatformGetCursorPos( const SFG_Window *window, GLboolean client, SFG_XYUse *mouse_pos );
 void fgPlatformPositionWindow( SFG_Window *window, int x, int y );
 
+NSCursor *fghCocoaEffectiveCursor( const SFG_Window *window ); /* see fg_cursor_cocoa.m */
+
 /* CVDisplayLink callback function */
 CVReturn fgDisplayLinkCallback( CVDisplayLinkRef displayLink,
     const CVTimeStamp                           *now,
@@ -347,6 +349,22 @@ static void fghCocoaContentOriginToFreeglut( const SFG_Window *window, NSRect co
     [self addTrackingArea:_mouseTrackingArea];
 
     [super updateTrackingAreas];
+}
+
+// Apply the glutSetCursor cursor (stored by fgPlatformSetCursor) whenever
+// AppKit rebuilds this view's cursor rects. A nil cursor (GLUT_CURSOR_INHERIT
+// all the way up) leaves the system default in place.
+- (void)resetCursorRects
+{
+    AUTORELEASE_POOL;
+
+    NSCursor *cursor = self.fgWindow ? fghCocoaEffectiveCursor( self.fgWindow ) : nil;
+    if ( cursor ) {
+        [self addCursorRect:self.bounds cursor:cursor];
+    }
+    else {
+        [super resetCursorRects];
+    }
 }
 
 #pragma mark Mouse Section
@@ -1323,11 +1341,13 @@ void fgPlatformCloseWindow( SFG_Window *window )
     }
 
     [context release];
+    [(NSCursor *)window->Window.pContext.Cursor release];
 
     window->Window.Handle               = nil;
     window->Window.Context              = nil;
     window->Window.pContext.PixelFormat = nil;
     window->Window.pContext.View        = nil;
+    window->Window.pContext.Cursor      = nil;
 }
 
 /*


### PR DESCRIPTION
How it works: rather than forcing the cursor globally, it uses AppKit's cursor-rect mechanism so the cursor is per-window and only applies while the pointer is over that window's view — matching GLUT semantics on X11/Windows.

- src/cocoa/fg_internal_cocoa.h — added a Cursor field (NSCursor *) to CocoaPlatformContext; nil represents GLUT_CURSOR_INHERIT.
- src/cocoa/fg_cursor_cocoa.m — fgPlatformSetCursor maps the GLUT cursor ID to an NSCursor, stores it on the window, and invalidates cursor rects for that window and (recursively) its subwindows so inheriting children update too. fghCocoaEffectiveCursor walks up the parent chain to resolve inheritance, same as X11's XUndefineCursor behavior.
- src/cocoa/fg_window_cocoa.m — fgOpenGLView overrides resetCursorRects to apply the resolved cursor over its bounds, and fgPlatformCloseWindow releases the stored cursor.

Mapping notes, since macOS's public cursor set doesn't cover everything GLUT defines:

- GLUT_CURSOR_NONE uses a transparent 16×16 cursor image (the per-window equivalent of X11's empty pixmap cursor — NSCursor hide would have been global).
- The four corner-resize cursors use the frameResizeCursorFromPosition:inDirections: API on macOS 15+, falling back to crosshair on older systems/SDKs.
- HELP, CYCLE, and WAIT fall back to the arrow (no public equivalents; macOS shows its own beachball when busy), SPRAY and FULL_CROSSHAIR demote to crosshair (X11 demotes FULL_CROSSHAIR the same way), and both arrows map to the standard arrow since macOS has no mirrored variant. Unknown IDs hit fgError, matching X11.

NOTE: written mainly using Claude Opus 4.8

TESTING: This cursor implementation has been used in private repositories and works as expected. As mentioned above, not all cursors are natively supported on macOS.