### PR TITLE
CI: pin Windows MSVC runner to 2022

### DIFF
--- a/.github/workflows/build_win_msvc.yml
+++ b/.github/workflows/build_win_msvc.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Addresses MSVC [build failures](https://github.com/freeglut/freeglut/actions/runs/28124589745/job/83284999800)