### PR TITLE
CI: use latest Windows runner without explicit MSVC generator

### DIFF
--- a/.github/workflows/build_win_msvc.yml
+++ b/.github/workflows/build_win_msvc.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -17,7 +17,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: generate project files
-      run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR="Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=freeglut-instdir .
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=freeglut-instdir .
 
     - name: build freeglut
       run: cmake --build . --config Release


### PR DESCRIPTION
The previous commit, 9cf2f8cc177ebd74160a991d1a6408c122fdf466, switched to the windows-2022 runner to match the explicit Visual Studio 2022 generator.

A less brittle solution is to use the latest Windows runner and let CMake select the appropriate generator.

See also #285