### PR TITLE
cocoa: avoid client pixel-store stack for bitmap fonts

### DIFF
--- a/src/fg_font.c
+++ b/src/fg_font.c
@@ -92,7 +92,12 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
     /* Find the character we want to draw */
     face = font->Characters[ character ];
 
-#ifdef GL_VERSION_1_1
+    /*
+     * Apple's OpenGL compatibility implementation handles the explicit
+     * pixel-store queries/restores below much more cheaply than its client
+     * attribute stack.  Only the six values changed here need preserving.
+     */
+#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
     glPushClientAttrib( GL_CLIENT_PIXEL_STORE_BIT );
 #else
 	{
@@ -117,7 +122,7 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
         ( float )( face[ 0 ] ), 0.0,  /* The raster advance -- inc. x,y */
         ( face + 1 )                  /* The packed bitmap data...      */
     );
-#ifdef GL_VERSION_1_1
+#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
     glPopClientAttrib();
 #else
 	glPixelStorei(GL_UNPACK_SWAP_BYTES, swbytes);
@@ -145,7 +150,7 @@ void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
     if ( !string || ! *string )
         return;
 
-#ifdef GL_VERSION_1_1
+#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
     glPushClientAttrib( GL_CLIENT_PIXEL_STORE_BIT );
 #else
 	{
@@ -190,7 +195,7 @@ void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
             x += ( float )( face[ 0 ] );
         }
 
-#ifdef GL_VERSION_1_1
+#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
     glPopClientAttrib();
 #else
 	glPixelStorei(GL_UNPACK_SWAP_BYTES, swbytes);

--- a/src/fg_font.c
+++ b/src/fg_font.c
@@ -95,9 +95,9 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
     /*
      * Apple's OpenGL compatibility implementation handles the explicit
      * pixel-store queries/restores below much more cheaply than its client
-     * attribute stack.  Only the six values changed here need preserving.
+     * attribute stack.  Verified this also helps the XQuartz path on macOS.
      */
-#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
+#if defined(GL_VERSION_1_1) && !defined(__APPLE__)
     glPushClientAttrib( GL_CLIENT_PIXEL_STORE_BIT );
 #else
 	{
@@ -122,7 +122,7 @@ void FGAPIENTRY glutBitmapCharacter( void* fontID, int character )
         ( float )( face[ 0 ] ), 0.0,  /* The raster advance -- inc. x,y */
         ( face + 1 )                  /* The packed bitmap data...      */
     );
-#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
+#if defined(GL_VERSION_1_1) && !defined(__APPLE__)
     glPopClientAttrib();
 #else
 	glPixelStorei(GL_UNPACK_SWAP_BYTES, swbytes);
@@ -150,7 +150,7 @@ void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
     if ( !string || ! *string )
         return;
 
-#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
+#if defined(GL_VERSION_1_1) && !defined(__APPLE__)
     glPushClientAttrib( GL_CLIENT_PIXEL_STORE_BIT );
 #else
 	{
@@ -195,7 +195,7 @@ void FGAPIENTRY glutBitmapString( void* fontID, const unsigned char *string )
             x += ( float )( face[ 0 ] );
         }
 
-#if defined(GL_VERSION_1_1) && !TARGET_HOST_MACOS_COCOA
+#if defined(GL_VERSION_1_1) && !defined(__APPLE__)
     glPopClientAttrib();
 #else
 	glPixelStorei(GL_UNPACK_SWAP_BYTES, swbytes);


### PR DESCRIPTION
Apple's OpenGL compatibility implementation handles explicit pixel-store queries and restores substantially more cheaply than `glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT)`.

See [bitmap-font-state-bench](https://github.com/drewwoods/freeglut/tree/bitmap-font-state-bench/progs/demos/bitmap_bench) for the benchmark code and detailed results.  Note the benchmark and report was generated by Claude Opus 5.0, but **verified**.

This was noticed when rendering ~1000 glyphs took ~2ms when using `glutBitmapChar()`

The overhead is mainly due to the state management performed per glyph. `glutBitmapString()` amortizes this overhead, so for typical-length strings the runtime is dominated by bitmap rasterization. 

Performance is trashed by larger glyphs for reasons unknown.

```
 Cost per glutBitmapCharacter (in situ), Apple GL / Cocoa:
                  clientattrib   getset
   8x13               1885 ns    492 ns    3.8x
   9x15               1950 ns    529 ns    3.7x
   tr10               1875 ns    459 ns    4.1x
   hel10              1889 ns    461 ns    4.1x
   hel12              1900 ns    492 ns    3.9x
   hel18             27400 ns  28000 ns    1.0x
   tr24              66500 ns  67600 ns    1.0x
```
 
