### PR TITLE
Cocoa build fixes

### DIFF
--- a/.github/workflows/build_macos_cocoa.yml
+++ b/.github/workflows/build_macos_cocoa.yml
@@ -18,13 +18,51 @@ jobs:
         true
 
     - name: generate makefile
-      run: cmake -DCMAKE_BUILD_TYPE=Release -DFREEGLUT_BUILD_DEMOS=ON -DFREEGLUT_COCOA=ON .
+      run: >-
+        cmake -S . -B build
+        -DCMAKE_BUILD_TYPE=Release
+        -DFREEGLUT_BUILD_DEMOS=ON
+        -DFREEGLUT_COCOA=ON
 
     - name: build freeglut
-      run: make
+      run: cmake --build build --config Release
 
     - name: stage install
-      run: DESTDIR=freeglut-instdir make install
+      run: DESTDIR="$PWD/freeglut-instdir" cmake --install build --config Release
+
+    - name: verify installed shared library
+      run: |
+        smoke_prefix="$RUNNER_TEMP/freeglut-prefix"
+        cmake -S . -B "$RUNNER_TEMP/freeglut-smoke-build" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="$smoke_prefix" \
+          -DFREEGLUT_BUILD_DEMOS=OFF \
+          -DFREEGLUT_BUILD_STATIC_LIBS=OFF \
+          -DFREEGLUT_COCOA=ON
+        cmake --build "$RUNNER_TEMP/freeglut-smoke-build" --config Release
+        cmake --install "$RUNNER_TEMP/freeglut-smoke-build" --config Release
+
+        cat > "$RUNNER_TEMP/freeglut-link-smoke.c" <<'EOF'
+        #include <GL/freeglut.h>
+
+        static void (*volatile freeglut_symbol)(int *, char **) = glutInit;
+
+        int main(void)
+        {
+            return freeglut_symbol == 0;
+        }
+        EOF
+        export PKG_CONFIG_PATH="$smoke_prefix/lib/pkgconfig"
+        cc "$RUNNER_TEMP/freeglut-link-smoke.c" \
+          $(pkg-config --cflags --libs glut) \
+          -o "$RUNNER_TEMP/freeglut-link-smoke"
+        test "$(otool -D "$smoke_prefix/lib/libglut.dylib" | tail -n 1)" = \
+          "$smoke_prefix/lib/libglut.3.dylib"
+        if otool -l "$RUNNER_TEMP/freeglut-link-smoke" | grep -q LC_RPATH; then
+          echo "unexpected LC_RPATH in pkg-config consumer"
+          exit 1
+        fi
+        "$RUNNER_TEMP/freeglut-link-smoke"
 
     - uses: actions/upload-artifact@v4
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,11 @@ ELSE()
 
     IF(FREEGLUT_BUILD_SHARED_LIBS)
       SET_TARGET_PROPERTIES(freeglut PROPERTIES VERSION ${SO_MAJOR}.${SO_MINOR}.${SO_REV} SOVERSION ${SO_MAJOR} OUTPUT_NAME ${LIBNAME})
+      IF(APPLE)
+        # Include the install path in lib, so it can be linked with -lglut
+        # without the need for RPATH
+        SET_TARGET_PROPERTIES(freeglut PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+      ENDIF()
     ENDIF()
     IF(FREEGLUT_BUILD_STATIC_LIBS)
       SET_TARGET_PROPERTIES(freeglut_static PROPERTIES OUTPUT_NAME ${LIBNAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,8 @@ ADD_DEMO(cursors         progs/demos/cursors/cursors.c)
 # Define static build dependencies
 IF(WIN32)
   SET(PC_LIBS_PRIVATE "-lopengl32 -lwinmm -lgdi32")
+ELSEIF(FREEGLUT_COCOA)
+  SET(PC_LIBS_PRIVATE "-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo -lm")
 ELSEIF(FREEGLUT_GLES)
   IF(ANDROID)
     SET(PC_LIBS_PRIVATE "-llog -landroid -lGLESv2 -lGLESv1_CM -lEGL -lm")


### PR DESCRIPTION
This PR includes 3 commits:
### [build: use an absolute install name for the macOS shared library](https://github.com/freeglut/freeglut/commit/7f02d3beba78b5ab21cac7852e4e35df5e33d9e8)
This allows binaries to be linked **wthout** an RPATH.

Currently, the way macOS freeglut libraries are constructed, they mandate that the binaries linking to them must either:
- `DYLD_LIBRARY_PATH=` env var
 - RPATH during linkage, `(-Wl,-rpath)`
 

For example:
```
# just linking to the library fails
❯  gcc -Wall -DGL_SILENCE_DEPRECATION  -framework Cocoa -framework OpenGL -lglut  lens-flare.c \
 -o /tmp/build/lens-flare lens-flare.c
❯ /tmp/build/lens-flare
dyld[11378]: Library not loaded: @rpath/libglut.3.dylib
  Referenced from: <1E65D32B-A016-3BD8-AF1E-A77AE1BCD3AC> /private/tmp/build/lens-flare
  Reason: no LC_RPATH's found
[1]    11378 abort      /tmp/build/lens-flare

# `DYLD_LIBRARY_PATH=` env var
❯ export DYLD_LIBRARY_PATH=/usr/local/lib
❯ /tmp/build/lens-flare
^^ success

# RPATH during linkage, `(-Wl,-rpath)`
❯  gcc -Wall -DGL_SILENCE_DEPRECATION  -framework Cocoa -framework OpenGL -lglut  lens-flare.c \
 -o /tmp/build/lens-flare lens-flare.c -Wl,-rpath,/usr/local/lib
❯ /tmp/build/lens-flare
^^ success
```

You can see this by looking at the library:

```
❯ otool -L /usr/local/lib/libglut.3.dylib
/usr/local/lib/libglut.3.dylib:
	@rpath/libglut.3.dylib (compatibility version 3.0.0, current version 3.13.0) <-- NOTE Rpath
	...
```

With this patch, the library has an absolute install name, so binaries can simply link with -lglut.  No `-Wl,-rpath` or `DYLD_LIBRARY_PATH` is required.

Both homebrew and XQuartz install the libglut libraries **without** an rpath.
 - homebrew apparently uses a [cleanup step](https://github.com/Homebrew/brew/blob/1490a40d90a58dd7b0d7149aa42b520a50e3e17b/Library/Homebrew/extend/os/mac/keg_relocate.rb#L79)
 -  XQuartz [sets the missing `INSTALL_NAME_DIR` ](https://github.com/XQuartz/XQuartz/blob/b196c2ba645e6b8ebc43706e4bb8d12e1868db71/compile.sh#L558)which mirrors this patch 


### [build: advertise Cocoa frameworks in pkg-config metadata](https://github.com/freeglut/freeglut/commit/6462224acee97ca4280e62d5004da211a92cd130)

The pkg-configs incorrectly used X11 libs with the Cocoa build

### [CI: build macOS Cocoa out of source and verify the installed library](https://github.com/freeglut/freeglut/commit/7f425210e1aa7b692f7cb12fdfc75ed9014abbb7) 
   - Note LLM generated but seems sane, there is a smoke to ensure a freeglut binary can be linked with just -lglut and glutInit is a valid symbol

Part of:
- #195 